### PR TITLE
Add Claude Agent SDK harness support alongside Pi SDK

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,12 @@
-# Pi reads provider credentials from these — set whichever matches your model.
+# The agent harness reads provider credentials from these — set whichever
+# matches your model.
 ANTHROPIC_API_KEY=
 OPENAI_API_KEY=
+
+# Agent harness that drives conversations:
+#   pi     - Pi Coding Agent SDK (multi-provider; default)
+#   claude - Claude Agent SDK (Anthropic models only; needs ANTHROPIC_API_KEY)
+PIPIPE_HARNESS=pi
 
 # Workspace root for file/system tools.
 PIPIPE_WORKSPACE=/Users/mg/workspace

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pi-pipe
 
-Pi Pipe is a personal AI assistant you run on your own machine. It answers you on the channels you already use (Telegram, Discord) or your terminal. It connects directly to the [Pi Coding Agent SDK](https://pi.dev/docs/latest/sdk).
+Pi Pipe is a personal AI assistant you run on your own machine. It answers you on the channels you already use (Telegram, Discord) or your terminal. It runs on a configurable **agent harness** — either the [Pi Coding Agent SDK](https://pi.dev/docs/latest/sdk) (multi-provider; default) or the [Claude Agent SDK](https://docs.claude.com/en/api/agent-sdk/overview) (Anthropic models). Both expose the same chat behavior, so you can switch with one setting.
 
 Inspired by [openclaw/openclaw](https://github.com/openclaw/openclaw).
 
@@ -36,9 +36,10 @@ First run starts the interactive setup wizard:
 
 1. **Choose platform** — select Telegram, Discord, or CLI (local terminal)
 2. **Enter bot token** — required for Telegram/Discord, skipped in CLI mode
-3. **Select model** — preset list (Claude, GPT-5, …) or free-form entry (supports `provider/model-id`)
-4. **Set workspace** — directory Pi can access (defaults to current directory)
-5. **Set personality** — give your assistant a name and description
+3. **Choose agent harness** — Pi Coding Agent SDK (multi-provider) or Claude Agent SDK (Anthropic only)
+4. **Select model** — preset list (Claude, GPT-5, …) or free-form entry (supports `provider/model-id`)
+5. **Set workspace** — directory the agent can access (defaults to current directory)
+6. **Set personality** — give your assistant a name and description
 
 Settings are saved to `~/.pi-pipe/settings.json`.
 
@@ -144,6 +145,7 @@ Configuration is stored in `~/.pi-pipe/settings.json` and created by the onboard
   "channel": "telegram",
   "token": "your-bot-token",
   "allowFrom": ["user-id-1", "user-id-2"],
+  "harness": "pi",
   "model": "claude-sonnet-4-5",
   "workspace": "/path/to/your/workspace",
   "personality": {
@@ -159,18 +161,21 @@ Configuration is stored in `~/.pi-pipe/settings.json` and created by the onboard
 | `token`         | Bot token from [BotFather](https://t.me/botfather) or [Discord Developer Portal](https://discord.com/developers/applications) |
 | `allowFrom`     | Array of allowed user IDs (empty = allow everyone)                                                                            |
 | `allowChannels` | Discord-only: channel ID allowlist (empty/missing = allow all channels)                                                       |
-| `model`         | Pi model name (e.g. `claude-sonnet-4-5`, `gpt-5`, `kimi-k2`, or `provider/model-id` for explicit provider)                    |
-| `workspace`     | Root directory Pi can access                                                                                                  |
+| `harness`       | Agent harness: `pi` (Pi Coding Agent SDK, multi-provider; default) or `claude` (Claude Agent SDK, Anthropic only)             |
+| `model`         | Model name (e.g. `claude-sonnet-4-5`, `gpt-5`, `kimi-k2`, or `provider/model-id`; non-Anthropic ids require the `pi` harness) |
+| `workspace`     | Root directory the agent can access                                                                                           |
 | `personality`   | Optional: give your assistant a `name` and `traits` description                                                               |
 | `env`           | Optional: environment variables to inject at startup                                                                          |
 
 ### Authentication
 
-Pi reads provider credentials from the environment:
+The active harness reads provider credentials from the environment:
 
-- `ANTHROPIC_API_KEY` — required for Claude models
-- `OPENAI_API_KEY` — required for GPT / OpenAI models
-- Other providers: see the [Pi providers docs](https://pi.dev/docs/latest/providers)
+- `ANTHROPIC_API_KEY` — required for Claude models (and for the entire `claude` harness)
+- `OPENAI_API_KEY` — required for GPT / OpenAI models (Pi harness)
+- Other providers (Pi harness): see the [Pi providers docs](https://pi.dev/docs/latest/providers)
+
+The `claude` harness only supports Anthropic models; use the `pi` harness for any other provider.
 
 Set them in your shell profile or in `~/.pi-pipe/.env`.
 
@@ -180,6 +185,7 @@ For options not in the settings file, use a `.env` file in `~/.pi-pipe/` or the 
 
 | Variable                          | What it does                                                               |
 | --------------------------------- | -------------------------------------------------------------------------- |
+| `PIPIPE_HARNESS`                  | Agent harness: `pi` (default) or `claude` (overrides the settings value)   |
 | `PIPIPE_SESSION_STORE_PATH`       | Where to save session data (default: `{workspace}/data/sessions.json`)     |
 | `PIPIPE_MAX_TOOL_ITERATIONS`      | Max tool calls per turn (default: 20)                                      |
 | `PIPIPE_SUMMARY_PROMPT_ENABLED`   | Enable summary prompt templates                                            |

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "pi-pipe",
       "version": "0.1.0",
       "dependencies": {
+        "@anthropic-ai/claude-agent-sdk": "^0.3.183",
         "@earendil-works/pi-ai": "^0.74.0",
         "@earendil-works/pi-coding-agent": "^0.74.0",
         "better-sqlite3": "^12.8.0",
@@ -48,13 +49,143 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@anthropic-ai/claude-agent-sdk": {
+      "version": "0.3.183",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.183.tgz",
+      "integrity": "sha512-rAKws76RKdFu+DK5q9wYN0AGLRdPrw0vGd+TMzSFynFdxwUAehYc9vUKJoK27j2xRoHFdNt+JDsih5BzsUzi+Q==",
+      "license": "SEE LICENSE IN README.md",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.183",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.183",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.183",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.183",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.183",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.183",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.183",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.183"
+      },
+      "peerDependencies": {
+        "@anthropic-ai/sdk": ">=0.93.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
+      "version": "0.3.183",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.183.tgz",
+      "integrity": "sha512-o/+sxwKgXuw6RG5cERWjvcvL1CDSPe/TaXMhax+dq+V4lDOI5iTqg3y5Wfb6dL3xlWoTA2OhWowDQllKbE04LQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
+      "version": "0.3.183",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.183.tgz",
+      "integrity": "sha512-V7Cf8JeD5EPf4MPomFUlEblCIQI0wg+aWdOSqvfMsDmCBEHljd52CQ3a7W263oVt6I7QUfRTpX2KNvdma56rDA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
+      "version": "0.3.183",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.183.tgz",
+      "integrity": "sha512-qqnSf85D3uBH7kRHLGOMhr7aQrREUZ4hUlCztrkJe/twUT4bmJsO86zamnAf7vOYeCul/sHYwBMmXtOfI+cHZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
+      "version": "0.3.183",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.183.tgz",
+      "integrity": "sha512-ua6XaiCcYYKfd0CY9cjoyYnTQWI2GocpbP7Gwvmr+9taW/lTpQGVQH3FrF2VFKXVSt7AaVE6Z7WN9oPxcxl3VA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
+      "version": "0.3.183",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.183.tgz",
+      "integrity": "sha512-GvfNp9XsKWFvr0EH3NgX2pqzHPYhFeqhOmVc4A+2e+GdxBMYUEa0ylfPLJItahQU9FkTJAw2oQNnzTHPPm1GxA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
+      "version": "0.3.183",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.183.tgz",
+      "integrity": "sha512-wp+p+4xeZOW+h4InMKR7nIdGlgYftXyR+ErOVz7i2tMRcKuYMoc5jRIYjdJkuETMSr5nsRj0rDeO5gG7M6MGZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
+      "version": "0.3.183",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.183.tgz",
+      "integrity": "sha512-cGyMC9YDsrCQ4av74dMVa2liOb5oLFX4+1SxwJGRCW7mBVBazcM6rg7ifWbd9XfkDhNPKOIfyiloipyMfoaE4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
+      "version": "0.3.183",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.183.tgz",
+      "integrity": "sha512-h/XzbrSmXGroTk/FYKR6J4/8G9vDb1HUUUeNXeBGqGW1kppIiWPJKLRzjtSe0brVjADOKOT6tE5IHK0mV/1gBw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.91.1",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
-      "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
+      "version": "0.105.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.105.0.tgz",
+      "integrity": "sha512-sDyu+aM9cE6uZE+HgRjjHRb+qqb87GHZOx+8bE0YlWetdL1YcVLxn8h9ltxGOflyChTe6PMEo50kMQV4cw0hfg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "json-schema-to-ts": "^3.1.1"
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
       },
       "bin": {
         "anthropic-ai-sdk": "bin/cli"
@@ -716,6 +847,26 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-ai/node_modules/@anthropic-ai/sdk": {
+      "version": "0.91.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
+      "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@earendil-works/pi-ai/node_modules/chalk": {
@@ -1484,6 +1635,19 @@
         }
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1848,6 +2012,71 @@
         "zod": "^3.25.0 || ^4.0.0",
         "zod-to-json-schema": "^3.25.0"
       }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@nodable/entities": {
       "version": "2.1.0",
@@ -2461,6 +2690,13 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@tokenizer/inflate": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
@@ -2992,6 +3228,20 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -3040,6 +3290,48 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ansi-regex": {
       "version": "6.2.2",
@@ -3182,6 +3474,45 @@
         "readable-stream": "^3.4.0"
       }
     },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/bowser": {
       "version": "2.14.1",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
@@ -3238,6 +3569,16 @@
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -3246,6 +3587,37 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/callsites": {
@@ -3385,11 +3757,72 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -3481,6 +3914,16 @@
         "node": ">= 14"
       }
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -3547,6 +3990,21 @@
         "url": "https://dotenvx.com"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -3563,11 +4021,28 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
@@ -3578,12 +4053,45 @@
         "once": "^1.4.0"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.27.3",
@@ -3635,6 +4143,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -3861,6 +4376,39 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/expand-template": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
@@ -3878,6 +4426,69 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
       }
     },
     "node_modules/extend": {
@@ -3925,6 +4536,30 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense",
+      "peer": true
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/fast-xml-builder": {
       "version": "1.2.0",
@@ -4050,6 +4685,28 @@
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
       "license": "MIT"
     },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -4130,6 +4787,26 @@
         "node": ">=12.20.0"
       }
     },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
@@ -4149,6 +4826,16 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/gaxios": {
@@ -4198,6 +4885,45 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-stream": {
@@ -4362,6 +5088,19 @@
         "node": ">=14"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -4377,6 +5116,32 @@
         "node": ">=8"
       }
     },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/highlight.js": {
       "version": "10.7.3",
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
@@ -4384,6 +5149,16 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.26",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.26.tgz",
+      "integrity": "sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
       }
     },
     "node_modules/hosted-git-info": {
@@ -4404,6 +5179,27 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
@@ -4429,6 +5225,23 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ieee754": {
@@ -4509,6 +5322,16 @@
         "node": ">= 12"
       }
     },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -4541,11 +5364,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -4627,6 +5456,16 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-yaml": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
@@ -4675,6 +5514,13 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -4852,6 +5698,39 @@
         "node": ">= 18"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/mime-db": {
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
@@ -4975,6 +5854,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/netmask": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
@@ -5041,6 +5930,32 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/once": {
@@ -5209,6 +6124,16 @@
       "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
       "license": "MIT"
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/partial-json": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
@@ -5244,7 +6169,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5264,6 +6188,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/pathe": {
@@ -5307,6 +6242,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/playwright": {
@@ -5482,6 +6427,20 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/proxy-agent": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
@@ -5536,6 +6495,48 @@
         "node": ">=6"
       }
     },
+    "node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -5579,6 +6580,16 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5657,6 +6668,23 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -5677,6 +6705,13 @@
       ],
       "license": "MIT"
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/semver": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
@@ -5689,11 +6724,64 @@
         "node": ">=10"
       }
     },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC",
+      "peer": true
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -5706,10 +6794,85 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/siginfo": {
@@ -5834,6 +6997,27 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/std-env": {
       "version": "3.10.0",
@@ -6260,6 +7444,16 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/token-types": {
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
@@ -6354,6 +7548,39 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/typebox": {
       "version": "1.1.38",
       "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
@@ -6425,6 +7652,16 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -6452,6 +7689,16 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist-node/bin/uuid"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/vite": {
@@ -7046,7 +8293,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "node": ">=20.18.1"
   },
   "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.3.183",
     "@earendil-works/pi-ai": "^0.74.0",
     "@earendil-works/pi-coding-agent": "^0.74.0",
     "better-sqlite3": "^12.8.0",

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -265,10 +265,7 @@ export class DiscordChannel implements Channel {
     }
 
     // Skip channel allowlist for DMs
-    if (
-      message.channel.type !== ChannelType.DM &&
-      !this.isChannelAllowed(message.channelId)
-    ) {
+    if (message.channel.type !== ChannelType.DM && !this.isChannelAllowed(message.channelId)) {
       this.logger.warn('channel.discord.denied_channel', {
         senderId,
         chatId: message.channelId
@@ -313,7 +310,7 @@ export class DiscordChannel implements Channel {
         })
         const history = Array.from(messages.values())
           .reverse()
-          .map(m => {
+          .map((m) => {
             const author = m.author.username
             const text = m.content?.trim() || ''
             return text ? `${author}: ${text}` : null

--- a/src/commands/definitions/session.ts
+++ b/src/commands/definitions/session.ts
@@ -1,3 +1,4 @@
+import type { SessionRecord } from '../../core/types.js'
 import type { CommandDefinition, CommandContext, CommandResult } from '../types.js'
 
 /**
@@ -50,7 +51,7 @@ export function sessionListCommand(
  * Shows info about the current chat's session.
  */
 export function sessionInfoCommand(
-  getSession: (conversationKey: string) => { sessionFile: string; updatedAt: string } | undefined
+  getSession: (conversationKey: string) => SessionRecord | undefined
 ): CommandDefinition {
   return {
     name: 'session_info',
@@ -67,18 +68,21 @@ export function sessionInfoCommand(
         return { content: 'No active session for this chat.' }
       }
       // Show only the basename so the absolute path isn't leaked even to
-      // admins via casual screenshot/copy-paste of bot output. Guard against
-      // legacy records that may not carry `sessionFile` (e.g. an older
-      // `sessions.json` from before the rebrand).
-      const sessionFile = session.sessionFile
-      const basename = sessionFile
-        ? (sessionFile.split(/[/\\]/).pop() ?? '') || sessionFile
-        : '(legacy entry — start a new session to upgrade)'
+      // admins via casual screenshot/copy-paste of bot output. The reference
+      // shape depends on the active harness: Pi persists a `sessionFile` path,
+      // Claude persists an opaque `sessionId`. Guard against legacy records
+      // that carry neither.
+      let ref: string
+      if (session.sessionFile) {
+        const file = session.sessionFile
+        ref = `Session file: \`${(file.split(/[/\\]/).pop() ?? '') || file}\``
+      } else if (session.sessionId) {
+        ref = `Session id: \`${session.sessionId}\``
+      } else {
+        ref = 'Session: (legacy entry — start a new session to upgrade)'
+      }
       return {
-        content:
-          `**Session info:**\n` +
-          `• Session file: \`${basename}\`\n` +
-          `• Last active: ${session.updatedAt}`
+        content: `**Session info:**\n` + `• ${ref}\n` + `• Last active: ${session.updatedAt}`
       }
     }
   }

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -3,7 +3,6 @@ import { fileURLToPath } from 'node:url'
 import type { PiPipeConfig } from '../config/schema.js'
 import { loadConfig } from '../config/load.js'
 import type { ModelClient } from '../core/model-client.js'
-import { PiClient } from '../core/pi-client.js'
 import type { SessionStore } from '../core/session-store.js'
 
 const projectRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
@@ -89,7 +88,7 @@ export function setupCommands(
   registry.register(
     piModelCommand(
       () => config.model,
-      pi instanceof PiClient ? (model) => (pi as PiClient).setModel(model) : undefined
+      (model) => pi.setModel(model)
     )
   )
 

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -13,6 +13,11 @@ function parseCsv(input: string | undefined): string[] {
     .filter(Boolean)
 }
 
+/** Normalizes a harness string, falling back to 'pi' for unknown/missing values. */
+function parseHarness(input: string | undefined): 'pi' | 'claude' {
+  return input === 'claude' ? 'claude' : 'pi'
+}
+
 /**
  * Loads runtime configuration.
  *
@@ -46,6 +51,7 @@ export function loadConfig(): PiPipeConfig {
     const cliEnabled = s.channel === 'cli'
 
     return configSchema.parse({
+      harness: parseHarness(process.env.PIPIPE_HARNESS ?? s.harness),
       model: s.model,
       workspace: s.workspace,
       channels: {
@@ -76,6 +82,7 @@ export function loadConfig(): PiPipeConfig {
   }
 
   return configSchema.parse({
+    harness: parseHarness(process.env.PIPIPE_HARNESS),
     model: process.env.PIPIPE_MODEL ?? '',
     workspace: process.env.PIPIPE_WORKSPACE ?? process.cwd(),
     channels: {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -20,6 +20,12 @@ const cliChannelSchema = z.object({
  * Runtime configuration schema for Pi Pipe.
  */
 export const configSchema = z.object({
+  /**
+   * Which agent harness drives conversations:
+   * - `pi`     — the Pi Coding Agent SDK (multi-provider; default).
+   * - `claude` — the Claude Agent SDK (Anthropic models only).
+   */
+  harness: z.enum(['pi', 'claude']).default('pi'),
   model: z.string(),
   workspace: z.string(),
   channels: z.object({

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -16,6 +16,8 @@ export interface Settings {
   allowFrom: string[]
   // Optional allowlist of Discord channel IDs. Empty/missing means allow all channels.
   allowChannels?: string[]
+  // Which agent harness drives conversations. Defaults to 'pi' when omitted.
+  harness?: 'pi' | 'claude'
   model: string
   workspace: string
   personality?: PersonalitySettings

--- a/src/core/claude-client.ts
+++ b/src/core/claude-client.ts
@@ -70,7 +70,9 @@ export class ClaudeClient implements ModelClient {
 
       for (const block of content) {
         if (block.type === 'text') {
-          text = block.text
+          // Accumulate so a message with multiple text blocks isn't truncated
+          // to its last block, and streamed updates stay cumulative.
+          text += block.text
           await this.transcript.log(conversationKey, { type: 'assistant_text', text })
           await this.publishUpdate(context, {
             kind: 'text_streaming',

--- a/src/core/claude-client.ts
+++ b/src/core/claude-client.ts
@@ -1,0 +1,254 @@
+import { query } from '@anthropic-ai/claude-agent-sdk'
+import type { SDKMessage } from '@anthropic-ai/claude-agent-sdk'
+
+import type { PiPipeConfig } from '../config/schema.js'
+import type { ModelClient } from './model-client.js'
+import { SessionStore } from './session-store.js'
+import { buildSystemPrompt } from './system-prompt.js'
+import { TranscriptLogger } from './transcript-logger.js'
+import type { AgentTurnUpdate, Logger, ToolContext } from './types.js'
+
+function summarizeToolResult(content: unknown): string {
+  if (typeof content === 'string') {
+    if (content.includes('API Error:')) return 'tool returned API error'
+    return 'tool returned result'
+  }
+  return 'tool returned result'
+}
+
+/**
+ * Runs Claude via the official Claude Agent SDK, one `query()` call per turn.
+ *
+ * This is the Claude counterpart to {@link PiClient}: both satisfy the same
+ * {@link ModelClient} contract, share the system prompt from
+ * `./system-prompt.js`, and translate their SDK's stream into the agent loop's
+ * {@link AgentTurnUpdate} events, so the surrounding app can't tell which
+ * harness is active.
+ *
+ * Sessions resume across turns via the `session_id` from the result message,
+ * persisted as a {@link SessionRef} `{ sessionId }`. Cancellation uses an
+ * `AbortController` passed to `query()`.
+ */
+export class ClaudeClient implements ModelClient {
+  private readonly transcript: TranscriptLogger
+  private readonly abortControllers = new Map<string, AbortController>()
+
+  constructor(
+    private config: PiPipeConfig,
+    private readonly store: SessionStore,
+    private readonly logger: Logger
+  ) {
+    this.transcript = new TranscriptLogger({
+      enabled: this.config.transcriptLog.enabled,
+      path: this.config.transcriptLog.path,
+      ...(this.config.transcriptLog.maxBytes != null
+        ? { maxBytes: this.config.transcriptLog.maxBytes }
+        : {}),
+      ...(this.config.transcriptLog.maxFiles != null
+        ? { maxFiles: this.config.transcriptLog.maxFiles }
+        : {})
+    })
+  }
+
+  private async publishUpdate(context: ToolContext, event: AgentTurnUpdate): Promise<void> {
+    if (!context.onUpdate) return
+    await context.onUpdate(event)
+  }
+
+  private async handleMessage(
+    message: SDKMessage,
+    conversationKey: string,
+    context: ToolContext,
+    toolNamesByCallId: Map<string, string>
+  ): Promise<{ text: string }> {
+    let text = ''
+
+    await this.transcript.log(conversationKey, { type: message.type })
+
+    if (message.type === 'assistant') {
+      const content = message.message.content
+
+      for (const block of content) {
+        if (block.type === 'text') {
+          text = block.text
+          await this.transcript.log(conversationKey, { type: 'assistant_text', text })
+          await this.publishUpdate(context, {
+            kind: 'text_streaming',
+            conversationKey,
+            message: 'Streaming response...',
+            text
+          })
+        } else if (block.type === 'tool_use') {
+          if (block.id) toolNamesByCallId.set(block.id, block.name)
+          this.logger.info('claude.tool_call_started', {
+            conversationKey,
+            toolName: block.name,
+            toolUseId: block.id
+          })
+          await this.publishUpdate(context, {
+            kind: 'tool_call_started',
+            conversationKey,
+            message: `Using tool: ${block.name}`,
+            toolName: block.name,
+            ...(block.id ? { toolUseId: block.id } : {})
+          })
+        }
+      }
+    }
+
+    if (message.type === 'user') {
+      const msgContent = message.message.content
+      const blocks = Array.isArray(msgContent) ? msgContent : []
+      for (const block of blocks) {
+        if (
+          typeof block === 'object' &&
+          block !== null &&
+          'type' in block &&
+          block.type === 'tool_result'
+        ) {
+          const toolResult = block as {
+            type: 'tool_result'
+            tool_use_id?: string
+            content?: unknown
+          }
+          const toolUseId = toolResult.tool_use_id
+          const toolName = toolUseId ? toolNamesByCallId.get(toolUseId) : undefined
+          const summary = summarizeToolResult(toolResult.content)
+          const failed = summary.includes('error')
+
+          if (failed) {
+            this.logger.warn('claude.tool_call_failed', { conversationKey, toolName, toolUseId })
+          } else {
+            this.logger.info('claude.tool_call_finished', { conversationKey, toolName, toolUseId })
+          }
+
+          await this.publishUpdate(context, {
+            kind: failed ? 'tool_call_failed' : 'tool_call_finished',
+            conversationKey,
+            message: failed
+              ? `Tool failed${toolName ? `: ${toolName}` : ''}`
+              : `Tool completed${toolName ? `: ${toolName}` : ''}`,
+            ...(toolName ? { toolName } : {}),
+            ...(toolUseId ? { toolUseId } : {})
+          })
+        }
+      }
+    }
+
+    return { text }
+  }
+
+  async runTurn(conversationKey: string, userText: string, context: ToolContext): Promise<string> {
+    const savedSession = this.store.get(conversationKey)
+    const abort = new AbortController()
+    this.abortControllers.set(conversationKey, abort)
+
+    await this.publishUpdate(context, {
+      kind: 'turn_started',
+      conversationKey,
+      message: 'Working on it...'
+    })
+    await this.transcript.log(conversationKey, { type: 'user', text: userText })
+
+    let responseText = ''
+    const toolNamesByCallId = new Map<string, string>()
+
+    try {
+      for await (const message of query({
+        prompt: userText,
+        options: {
+          ...(savedSession?.sessionId ? { resume: savedSession.sessionId } : {}),
+          model: this.config.model,
+          systemPrompt: {
+            type: 'preset',
+            preset: 'claude_code',
+            append: buildSystemPrompt(this.config)
+          },
+          permissionMode: 'bypassPermissions',
+          allowDangerouslySkipPermissions: true,
+          cwd: this.config.workspace,
+          abortController: abort
+        }
+      })) {
+        const { text } = await this.handleMessage(
+          message,
+          conversationKey,
+          context,
+          toolNamesByCallId
+        )
+        if (text) responseText = text
+
+        if (message.type === 'result') {
+          await this.store.set(conversationKey, { sessionId: message.session_id })
+
+          if (message.is_error) {
+            this.logger.error('claude.turn_failed', { conversationKey, subtype: message.subtype })
+            await this.publishUpdate(context, {
+              kind: 'turn_finished',
+              conversationKey,
+              message: 'Turn failed'
+            })
+            return 'Sorry, I hit an error while processing that request.'
+          }
+
+          this.logger.info('claude.turn_finished', { conversationKey })
+          await this.publishUpdate(context, {
+            kind: 'turn_finished',
+            conversationKey,
+            message: 'Turn finished'
+          })
+
+          const finalText = 'result' in message ? message.result : ''
+          return (
+            responseText || finalText || 'I completed processing but have no response to return.'
+          )
+        }
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      if (/abort/i.test(msg)) {
+        await this.publishUpdate(context, {
+          kind: 'turn_finished',
+          conversationKey,
+          message: 'Turn cancelled'
+        })
+        return responseText || 'Cancelled.'
+      }
+      this.logger.error('claude.turn_failed', { conversationKey, error: msg })
+      await this.publishUpdate(context, {
+        kind: 'turn_finished',
+        conversationKey,
+        message: 'Turn failed'
+      })
+      return responseText || `Sorry, I hit an error: ${msg.slice(0, 200)}`
+    } finally {
+      this.abortControllers.delete(conversationKey)
+    }
+
+    return responseText || 'I completed processing but have no response to return.'
+  }
+
+  cancelTurn(conversationKey: string): void {
+    this.abortControllers.get(conversationKey)?.abort()
+    this.abortControllers.delete(conversationKey)
+  }
+
+  closeAll(): void {
+    for (const ctrl of this.abortControllers.values()) ctrl.abort()
+    this.abortControllers.clear()
+  }
+
+  async startNewSession(conversationKey: string): Promise<void> {
+    await this.store.clear(conversationKey)
+  }
+
+  /**
+   * Switches the model used for subsequent turns. The Claude SDK takes the
+   * model per `query()` call, so this just updates the shared config; the next
+   * turn picks it up. Kept symmetric with {@link PiClient.setModel} so the
+   * `/pi_model` command works regardless of the active harness.
+   */
+  setModel(modelString: string): void {
+    this.config.model = modelString
+  }
+}

--- a/src/core/client-factory.ts
+++ b/src/core/client-factory.ts
@@ -1,13 +1,26 @@
 import type { PiPipeConfig } from '../config/schema.js'
+import { ClaudeClient } from './claude-client.js'
 import { PiClient } from './pi-client.js'
 import type { Logger } from './types.js'
 import type { ModelClient } from './model-client.js'
 import { SessionStore } from './session-store.js'
 
+/**
+ * Builds the {@link ModelClient} for the configured agent harness.
+ *
+ * This is the single place that knows about concrete harness implementations;
+ * everything downstream depends only on the {@link ModelClient} interface.
+ */
 export function createModelClient(
   config: PiPipeConfig,
   store: SessionStore,
   logger: Logger
 ): ModelClient {
-  return new PiClient(config, store, logger)
+  switch (config.harness) {
+    case 'claude':
+      return new ClaudeClient(config, store, logger)
+    case 'pi':
+    default:
+      return new PiClient(config, store, logger)
+  }
 }

--- a/src/core/guardrail-extension.ts
+++ b/src/core/guardrail-extension.ts
@@ -6,7 +6,7 @@ const BLOCKED_TOOLS = new Set([
   'write',
   'mcp__shell__execute',
   'mcp__filesystem__write',
-  'mcp__filesystem__edit',
+  'mcp__filesystem__edit'
 ])
 
 const BLOCKED_PREFIXES = ['spawn_', 'exec_']
@@ -22,7 +22,7 @@ const SENSITIVE_PATHS = [
   '/etc/passwd',
   '/var/lib/task-orchestrator',
   '/home/claude/webhook',
-  '/home/claude/webhook/secret',
+  '/home/claude/webhook/secret'
 ]
 
 function isBlocked(toolName: string): boolean {
@@ -55,9 +55,10 @@ export function createGuardrailExtension() {
       if (isBlocked(toolName)) {
         return {
           block: true,
-          content: `Tool "${toolName}" is not available in this public sandbox. ` +
+          content:
+            `Tool "${toolName}" is not available in this public sandbox. ` +
             'I can read files (except sensitive areas), search the web, and use safe MCP tools.',
-          isError: true,
+          isError: true
         }
       }
 
@@ -68,7 +69,7 @@ export function createGuardrailExtension() {
           return {
             block: true,
             content: `Cannot read "${path}" — this path is restricted in the public sandbox.`,
-            isError: true,
+            isError: true
           }
         }
       }
@@ -81,7 +82,7 @@ export function createGuardrailExtension() {
           return {
             block: true,
             content: `Cannot access "${path}" — this path is restricted in the public sandbox.`,
-            isError: true,
+            isError: true
           }
         }
       }

--- a/src/core/model-client.ts
+++ b/src/core/model-client.ts
@@ -18,8 +18,11 @@ export interface ModelClient {
   /** Forgets the conversation's session so the next turn starts fresh. */
   startNewSession(conversationKey: string): Promise<void>
   /**
-   * Switches the active model for this client. Implementations validate the
-   * model string and throw on an unknown model, leaving prior state intact.
+   * Switches the active model for subsequent turns. Validation is
+   * implementation-dependent: the Pi harness resolves the model against its
+   * registry and throws on an unknown model (leaving prior state intact),
+   * while the Claude harness accepts any string and defers errors to the next
+   * `query()` call (the SDK rejects unknown models at request time).
    */
   setModel(modelString: string): void
 }

--- a/src/core/model-client.ts
+++ b/src/core/model-client.ts
@@ -2,10 +2,24 @@ import type { ToolContext } from './types.js'
 
 /**
  * Shared LLM runtime contract used by the agent loop and slash commands.
+ *
+ * Every agent harness (Pi, Claude, …) implements this interface, so the rest
+ * of the app — the agent loop, command handlers, channels — is agnostic to
+ * which SDK is actually driving the conversation. Selection happens once, in
+ * {@link createModelClient}, based on `config.harness`.
  */
 export interface ModelClient {
+  /** Runs a single conversational turn and returns the assistant's text. */
   runTurn(conversationKey: string, userText: string, context: ToolContext): Promise<string>
+  /** Aborts an in-flight turn for the given conversation, if any. */
   cancelTurn(conversationKey: string): void
+  /** Tears down every live session (used on shutdown). */
   closeAll(): void
+  /** Forgets the conversation's session so the next turn starts fresh. */
   startNewSession(conversationKey: string): Promise<void>
+  /**
+   * Switches the active model for this client. Implementations validate the
+   * model string and throw on an unknown model, leaving prior state intact.
+   */
+  setModel(modelString: string): void
 }

--- a/src/core/pi-client.ts
+++ b/src/core/pi-client.ts
@@ -15,64 +15,10 @@ import type { Model } from '@earendil-works/pi-ai'
 import type { PiPipeConfig } from '../config/schema.js'
 import type { ModelClient } from './model-client.js'
 import { SessionStore } from './session-store.js'
+import { buildSystemPrompt } from './system-prompt.js'
 import { TranscriptLogger } from './transcript-logger.js'
 import { createGuardrailExtension } from './guardrail-extension.js'
 import type { AgentTurnUpdate, Logger, ToolContext } from './types.js'
-
-/** Base system prompt always appended — covers chat-app behavior and attachment protocol. */
-const BASE_SYSTEM_PROMPT = [
-  'You are a personal AI assistant running inside a chat app (Telegram, Discord, or CLI) via pi-pipe.',
-  '',
-  '## Communication style',
-  '- Be direct and concise — your human is reading on a phone, not a desktop.',
-  '- Bias toward action. When you can just do something, do it and report back.',
-  "- Don't repeat the question back. Just answer it.",
-  "- Don't pad responses with filler or unnecessary disclaimers.",
-  '- Use short paragraphs and line breaks. Avoid markdown tables — use plain text lists instead.',
-  '- If a response would be long, summarize and offer to elaborate.',
-  '',
-  '## File attachments',
-  'To send files (images, audio, documents) to the user, include file markers in your response text:',
-  '- [[file:/absolute/path/to/file.ext]] — sends the file as an attachment',
-  '- [[file:/absolute/path/to/file.ext|Optional caption]] — sends with a caption',
-  '',
-  'The markers are stripped from the visible message and the files are sent via the appropriate method:',
-  '- .mp3, .m4a, .ogg, .wav, .flac, .aac → sent as audio',
-  '- .jpg, .jpeg, .png, .gif, .webp → sent as photo',
-  '- .mp4, .avi, .mkv, .mov, .webm → sent as video',
-  '- Everything else → sent as document',
-  '',
-  'Multiple attachments can be included in one response. The file must exist on disk at the given absolute path.',
-  '',
-  '## Inline keyboards',
-  'To show interactive buttons below a message, include a keyboard marker:',
-  '- [[keyboard:Button1=callback1,Button2=callback2]] — one row with two buttons',
-  '- [[keyboard:Button1=callback1,Button2=callback2|Button3=callback3]] — two rows (pipe separates rows)',
-  '',
-  'When a user presses a button, you receive: [Button pressed]: callback_data',
-  'Use keyboards for quick choices, confirmations, or navigation. Keep callback_data short (<64 chars).',
-  'Only one keyboard marker per response. The keyboard attaches to the last text chunk.',
-  '',
-  '## Memory',
-  'You have a persistent memory system. Memories from past conversations may be included in your context.',
-  'To save something to memory for future conversations, include a marker in your response:',
-  '[[memory:key_name|content to remember]]',
-  '',
-  'Use descriptive keys like "user_preference_language" or "project_nodetool_status".',
-  'Only save information that would be useful in future conversations.'
-].join('\n')
-
-/** Builds the full system prompt: base instructions + optional personality. */
-function buildSystemPrompt(config: PiPipeConfig): string {
-  if (!config.personality?.name) return BASE_SYSTEM_PROMPT
-  const { name, traits } = config.personality
-  return [
-    `You are ${name}, a personal AI assistant that lives inside chat apps.`,
-    `Your personality: ${traits}.`,
-    '',
-    BASE_SYSTEM_PROMPT
-  ].join('\n')
-}
 
 /**
  * A Pi extension that contributes pi-pipe's instructions to the agent via the
@@ -260,7 +206,7 @@ export class PiClient implements ModelClient {
     })
 
     if (!saved?.sessionFile && session.sessionFile) {
-      await this.store.set(conversationKey, session.sessionFile)
+      await this.store.set(conversationKey, { sessionFile: session.sessionFile })
     }
 
     this.sessions.set(conversationKey, session)

--- a/src/core/session-store.ts
+++ b/src/core/session-store.ts
@@ -1,16 +1,17 @@
 import { mkdir, readFile, rename, rmdir, stat, writeFile } from 'node:fs/promises'
 import { dirname } from 'node:path'
 
-import type { SessionMap, SessionRecord } from './types.js'
+import type { SessionMap, SessionRecord, SessionRef } from './types.js'
 
 const LOCK_RETRIES = 10
 const LOCK_RETRY_DELAY_MS = 50
 const LOCK_STALE_MS = 10_000
 
 /**
- * File-backed session file path map.
+ * File-backed conversation session map.
  *
- * Persists only conversation key -> Pi session file path metadata.
+ * Persists only conversation key -> harness session reference metadata
+ * (a {@link SessionRef}: a Pi session-file path or a Claude session id).
  * Uses a directory-based lockfile to prevent concurrent write corruption
  * across multiple processes.
  */
@@ -46,9 +47,9 @@ export class SessionStore {
   }
 
   /** Upserts conversation mapping and persists to disk atomically. */
-  async set(conversationKey: string, sessionFile: string): Promise<void> {
+  async set(conversationKey: string, ref: SessionRef): Promise<void> {
     this.map[conversationKey] = {
-      sessionFile,
+      ...ref,
       updatedAt: new Date().toISOString()
     }
     await this.persist()

--- a/src/core/system-prompt.ts
+++ b/src/core/system-prompt.ts
@@ -1,0 +1,64 @@
+import type { PiPipeConfig } from '../config/schema.js'
+
+/**
+ * Base system prompt shared by every agent harness (Pi, Claude, …).
+ *
+ * It is intentionally harness-agnostic: it only describes the chat-app
+ * behaviour and the marker protocols (attachments, keyboards, memory) that the
+ * {@link AgentLoop} parses out of the response, never anything specific to a
+ * single SDK. Keeping it here means switching harnesses never changes how the
+ * assistant talks or what markers it understands.
+ */
+export const BASE_SYSTEM_PROMPT = [
+  'You are a personal AI assistant running inside a chat app (Telegram, Discord, or CLI) via pi-pipe.',
+  '',
+  '## Communication style',
+  '- Be direct and concise — your human is reading on a phone, not a desktop.',
+  '- Bias toward action. When you can just do something, do it and report back.',
+  "- Don't repeat the question back. Just answer it.",
+  "- Don't pad responses with filler or unnecessary disclaimers.",
+  '- Use short paragraphs and line breaks. Avoid markdown tables — use plain text lists instead.',
+  '- If a response would be long, summarize and offer to elaborate.',
+  '',
+  '## File attachments',
+  'To send files (images, audio, documents) to the user, include file markers in your response text:',
+  '- [[file:/absolute/path/to/file.ext]] — sends the file as an attachment',
+  '- [[file:/absolute/path/to/file.ext|Optional caption]] — sends with a caption',
+  '',
+  'The markers are stripped from the visible message and the files are sent via the appropriate method:',
+  '- .mp3, .m4a, .ogg, .wav, .flac, .aac → sent as audio',
+  '- .jpg, .jpeg, .png, .gif, .webp → sent as photo',
+  '- .mp4, .avi, .mkv, .mov, .webm → sent as video',
+  '- Everything else → sent as document',
+  '',
+  'Multiple attachments can be included in one response. The file must exist on disk at the given absolute path.',
+  '',
+  '## Inline keyboards',
+  'To show interactive buttons below a message, include a keyboard marker:',
+  '- [[keyboard:Button1=callback1,Button2=callback2]] — one row with two buttons',
+  '- [[keyboard:Button1=callback1,Button2=callback2|Button3=callback3]] — two rows (pipe separates rows)',
+  '',
+  'When a user presses a button, you receive: [Button pressed]: callback_data',
+  'Use keyboards for quick choices, confirmations, or navigation. Keep callback_data short (<64 chars).',
+  'Only one keyboard marker per response. The keyboard attaches to the last text chunk.',
+  '',
+  '## Memory',
+  'You have a persistent memory system. Memories from past conversations may be included in your context.',
+  'To save something to memory for future conversations, include a marker in your response:',
+  '[[memory:key_name|content to remember]]',
+  '',
+  'Use descriptive keys like "user_preference_language" or "project_nodetool_status".',
+  'Only save information that would be useful in future conversations.'
+].join('\n')
+
+/** Builds the full system prompt: base instructions + optional personality. */
+export function buildSystemPrompt(config: PiPipeConfig): string {
+  if (!config.personality?.name) return BASE_SYSTEM_PROMPT
+  const { name, traits } = config.personality
+  return [
+    `You are ${name}, a personal AI assistant that lives inside chat apps.`,
+    `Your personality: ${traits}.`,
+    '',
+    BASE_SYSTEM_PROMPT
+  ].join('\n')
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -73,10 +73,25 @@ export interface SentMessage {
 }
 
 /**
- * Persistent mapping record from conversation key to Pi session file path.
+ * Harness-agnostic reference to a persisted conversation session.
+ *
+ * Each harness resumes conversations differently, so the store keeps whatever
+ * the active harness needs:
+ * - Pi persists a session-file path (`sessionFile`) opened via `SessionManager`.
+ * - Claude persists an opaque `sessionId` passed back via `query({ resume })`.
+ *
+ * Both fields are optional; a record typically carries exactly one.
  */
-export interface SessionRecord {
-  sessionFile: string
+export interface SessionRef {
+  sessionFile?: string
+  sessionId?: string
+}
+
+/**
+ * Persistent mapping record from conversation key to a harness session
+ * reference, plus bookkeeping metadata.
+ */
+export interface SessionRecord extends SessionRef {
   updatedAt: string
 }
 

--- a/src/onboarding/wizard.ts
+++ b/src/onboarding/wizard.ts
@@ -95,7 +95,26 @@ async function collectCredentials(
 }
 
 /* ------------------------------------------------------------------ */
-/*  Step 5 – Choose model                                              */
+/*  Step 5 – Choose agent harness                                      */
+/* ------------------------------------------------------------------ */
+
+async function chooseHarness(
+  rl: readline.Interface,
+  current?: 'pi' | 'claude'
+): Promise<'pi' | 'claude'> {
+  const defaultChoice = current === 'claude' ? '2' : '1'
+  console.log(
+    '\nWhich agent harness should drive your assistant?\n' +
+      '  1) Pi Coding Agent SDK   (multi-provider: Claude, GPT, Gemini, …)\n' +
+      '  2) Claude Agent SDK      (Anthropic models only; needs ANTHROPIC_API_KEY)\n'
+  )
+  const choice = await ask(rl, `Enter 1 or 2 [${defaultChoice}]: `)
+  const effective = choice || defaultChoice
+  return effective === '2' ? 'claude' : 'pi'
+}
+
+/* ------------------------------------------------------------------ */
+/*  Step 6 – Choose model                                              */
 /* ------------------------------------------------------------------ */
 
 const PI_MODEL_PRESETS: Record<string, string> = {
@@ -211,6 +230,7 @@ export async function runOnboarding(existingSettings?: Settings): Promise<Settin
     }
     const channel = await chooseChannel(rl, existingSettings?.channel)
     const token = await collectCredentials(rl, channel, existingSettings?.token)
+    const harness = await chooseHarness(rl, existingSettings?.harness)
     const model = await chooseModel(rl, existingSettings?.model)
     const workspace = await chooseWorkspace(rl, existingSettings?.workspace)
     const personality = await choosePersonality(rl, existingSettings?.personality)
@@ -219,6 +239,7 @@ export async function runOnboarding(existingSettings?: Settings): Promise<Settin
       channel,
       token,
       allowFrom: existingSettings?.allowFrom ?? [],
+      harness,
       model,
       workspace,
       personality

--- a/src/onboarding/wizard.ts
+++ b/src/onboarding/wizard.ts
@@ -123,15 +123,45 @@ const PI_MODEL_PRESETS: Record<string, string> = {
   '3': 'gpt-5'
 }
 
-function getModelChoiceNumber(model: string): string {
+// The Claude harness passes the model straight into the Claude Agent SDK, which
+// only accepts Anthropic models — so its preset list omits non-Anthropic
+// options and the free-form prompt is scoped to Anthropic model ids.
+const CLAUDE_MODEL_PRESETS: Record<string, string> = {
+  '1': 'claude-haiku-4-5',
+  '2': 'claude-sonnet-4-5'
+}
+
+function getModelChoiceNumber(model: string, harness: 'pi' | 'claude'): string {
   if (model === 'claude-haiku-4-5') return '1'
   if (model === 'claude-sonnet-4-5') return '2'
+  if (harness === 'claude') return '3'
   if (model === 'gpt-5') return '3'
   return '4'
 }
 
-async function chooseModel(rl: readline.Interface, currentModel?: string): Promise<string> {
-  const defaultChoice = currentModel ? getModelChoiceNumber(currentModel) : '2'
+async function chooseModel(
+  rl: readline.Interface,
+  harness: 'pi' | 'claude',
+  currentModel?: string
+): Promise<string> {
+  const defaultChoice = currentModel ? getModelChoiceNumber(currentModel, harness) : '2'
+
+  if (harness === 'claude') {
+    console.log(
+      '\nWhich Claude model would you like to use? (the Claude harness is Anthropic-only)\n' +
+        '  1) Claude Haiku 4.5  (needs ANTHROPIC_API_KEY)\n' +
+        '  2) Claude Sonnet 4.5 (needs ANTHROPIC_API_KEY)\n' +
+        '  3) Other (free-form Anthropic model id, e.g. claude-opus-4-1)\n'
+    )
+    const choice = await ask(rl, `Enter 1–3 [${defaultChoice}]: `)
+    const effectiveChoice = choice || defaultChoice
+    if (effectiveChoice in CLAUDE_MODEL_PRESETS) return CLAUDE_MODEL_PRESETS[effectiveChoice]!
+
+    const currentLabel = currentModel ? ` [${currentModel}]` : ''
+    const custom = await ask(rl, `Enter Anthropic model id (e.g. claude-opus-4-1)${currentLabel}: `)
+    return custom || currentModel || 'claude-sonnet-4-5'
+  }
+
   console.log(
     '\nWhich model would you like to use?\n' +
       '  1) Claude Haiku 4.5  (needs ANTHROPIC_API_KEY)\n' +
@@ -231,7 +261,7 @@ export async function runOnboarding(existingSettings?: Settings): Promise<Settin
     const channel = await chooseChannel(rl, existingSettings?.channel)
     const token = await collectCredentials(rl, channel, existingSettings?.token)
     const harness = await chooseHarness(rl, existingSettings?.harness)
-    const model = await chooseModel(rl, existingSettings?.model)
+    const model = await chooseModel(rl, harness, existingSettings?.model)
     const workspace = await chooseWorkspace(rl, existingSettings?.workspace)
     const personality = await choosePersonality(rl, existingSettings?.personality)
 

--- a/tests/acceptance-discord-summary.test.ts
+++ b/tests/acceptance-discord-summary.test.ts
@@ -36,15 +36,23 @@ describe('acceptance: discord summary flow', () => {
 
     const send = vi.fn(async () => undefined)
     const fetch = vi.fn(async () => ({ isTextBased: () => true, send }))
-    ;(discord as any).client = { channels: { fetch } }
+    // The bot must be mentioned for onMessage to publish; `user` identifies the
+    // bot for mention detection, and the inbound channel exposes the history
+    // fetch used to build context (empty here).
+    ;(discord as any).client = { user: { id: 'bot' }, channels: { fetch } }
 
     await (discord as any).onMessage({
       author: { bot: false, id: 'u1' },
-      channel: { type: 0 },
+      channel: {
+        type: 0,
+        isTextBased: () => true,
+        messages: { fetch: vi.fn(async () => new Map()) }
+      },
       channelId: 'chan-1',
       content: 'summarize files in workspace',
       id: 'msg-1',
-      guildId: 'guild-1'
+      guildId: 'guild-1',
+      mentions: { has: () => true }
     })
 
     await (agent as any).processOnce()

--- a/tests/claude-client.test.ts
+++ b/tests/claude-client.test.ts
@@ -1,0 +1,337 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Mock the Agent SDK before any imports
+const queryMock = vi.fn()
+vi.mock('@anthropic-ai/claude-agent-sdk', () => ({
+  query: queryMock
+}))
+
+async function* makeQueryGen(frames: Record<string, unknown>[]) {
+  for (const frame of frames) {
+    yield frame
+  }
+}
+
+/** An async-iterable whose first iteration rejects — mimics `query()` throwing. */
+function makeThrowingQuery(error: Error): AsyncIterable<never> {
+  return {
+    [Symbol.asyncIterator]() {
+      return { next: () => Promise.reject(error) }
+    }
+  }
+}
+
+function makeConfig() {
+  return {
+    harness: 'claude' as const,
+    model: 'claude-sonnet-4-5' as const,
+    workspace: '/tmp/workspace',
+    channels: {
+      telegram: { enabled: false, token: '', allowFrom: [] },
+      discord: { enabled: false, token: '', allowFrom: [] }
+    },
+    summaryPrompt: { enabled: true, template: 'Workspace: {{workspace}} Request: {{request}}' },
+    transcriptLog: { enabled: false, path: '/tmp/transcript.jsonl' },
+    sessionStorePath: '/tmp/sessions.json',
+    maxToolIterations: 20
+  }
+}
+
+function makeStore() {
+  return {
+    get: vi.fn(() => undefined),
+    set: vi.fn(async () => undefined),
+    clear: vi.fn(async () => undefined)
+  }
+}
+
+describe('ClaudeClient (Claude Agent SDK)', () => {
+  beforeEach(() => {
+    queryMock.mockReset()
+  })
+
+  it('runs a turn, streams assistant text, and persists session id', async () => {
+    const { ClaudeClient } = await import('../src/core/claude-client.js')
+    const store = makeStore()
+
+    queryMock.mockReturnValue(
+      makeQueryGen([
+        {
+          type: 'assistant',
+          session_id: 'sess-new',
+          message: { content: [{ type: 'text', text: 'hello from assistant' }] }
+        },
+        {
+          type: 'result',
+          subtype: 'success',
+          is_error: false,
+          result: 'hello from assistant',
+          session_id: 'sess-new'
+        }
+      ])
+    )
+
+    const client = new ClaudeClient(makeConfig() as never, store as never, {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn()
+    })
+
+    const result = await client.runTurn('telegram:1', 'hello', {
+      workspace: '/tmp/workspace',
+      channel: 'telegram',
+      chatId: '1'
+    })
+
+    expect(result).toBe('hello from assistant')
+    expect(store.set).toHaveBeenCalledWith('telegram:1', { sessionId: 'sess-new' })
+
+    expect(queryMock).toHaveBeenCalledTimes(1)
+    const [callArgs] = queryMock.mock.calls[0] as [
+      { prompt: string; options: Record<string, unknown> }
+    ]
+    expect(callArgs.prompt).toBe('hello')
+    expect(callArgs.options.model).toBe('claude-sonnet-4-5')
+    expect(callArgs.options.cwd).toBe('/tmp/workspace')
+    expect(callArgs.options.permissionMode).toBe('bypassPermissions')
+    // System prompt is the shared marker protocol, appended to the preset.
+    const sp = callArgs.options.systemPrompt as { append: string }
+    expect(sp.append).toContain('[[file:')
+    expect(sp.append).toContain('[[memory:')
+  })
+
+  it('passes resume session id when available', async () => {
+    const { ClaudeClient } = await import('../src/core/claude-client.js')
+    const store = {
+      get: vi.fn(() => ({ sessionId: 'sess-existing', updatedAt: new Date().toISOString() })),
+      set: vi.fn(async () => undefined),
+      clear: vi.fn(async () => undefined)
+    }
+
+    queryMock.mockReturnValue(
+      makeQueryGen([
+        {
+          type: 'result',
+          subtype: 'success',
+          is_error: false,
+          result: 'resumed',
+          session_id: 'sess-existing'
+        }
+      ])
+    )
+
+    const client = new ClaudeClient(makeConfig() as never, store as never, {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn()
+    })
+
+    await client.runTurn('discord:abc', 'continue', {
+      workspace: '/tmp/workspace',
+      channel: 'discord',
+      chatId: 'abc'
+    })
+
+    const [callArgs] = queryMock.mock.calls[0] as [{ options: Record<string, unknown> }]
+    expect(callArgs.options.resume).toBe('sess-existing')
+  })
+
+  it('emits tool progress updates via onUpdate callback', async () => {
+    const { ClaudeClient } = await import('../src/core/claude-client.js')
+    const store = makeStore()
+
+    queryMock.mockReturnValue(
+      makeQueryGen([
+        {
+          type: 'assistant',
+          session_id: 'sess-1',
+          message: {
+            content: [
+              { type: 'tool_use', id: 'tool-1', name: 'WebSearch', input: { query: 'cats' } }
+            ]
+          }
+        },
+        {
+          type: 'user',
+          session_id: 'sess-1',
+          message: {
+            role: 'user',
+            content: [{ type: 'tool_result', tool_use_id: 'tool-1', content: 'done' }]
+          }
+        },
+        {
+          type: 'assistant',
+          session_id: 'sess-1',
+          message: { content: [{ type: 'text', text: 'final answer' }] }
+        },
+        {
+          type: 'result',
+          subtype: 'success',
+          is_error: false,
+          result: 'final answer',
+          session_id: 'sess-1'
+        }
+      ])
+    )
+
+    const onUpdate = vi.fn(async () => undefined)
+    const client = new ClaudeClient(makeConfig() as never, store as never, {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn()
+    })
+
+    const text = await client.runTurn('telegram:1', 'web search this', {
+      workspace: '/tmp/workspace',
+      channel: 'telegram',
+      chatId: '1',
+      onUpdate
+    })
+
+    expect(text).toBe('final answer')
+    expect(onUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 'turn_started', conversationKey: 'telegram:1' })
+    )
+    expect(onUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 'tool_call_started',
+        toolName: 'WebSearch',
+        toolUseId: 'tool-1'
+      })
+    )
+    expect(onUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 'tool_call_finished',
+        toolName: 'WebSearch',
+        toolUseId: 'tool-1'
+      })
+    )
+  })
+
+  it('returns error message on result with is_error=true', async () => {
+    const { ClaudeClient } = await import('../src/core/claude-client.js')
+    const store = makeStore()
+
+    queryMock.mockReturnValue(
+      makeQueryGen([
+        {
+          type: 'result',
+          subtype: 'error_during_execution',
+          is_error: true,
+          session_id: 'sess-err'
+        }
+      ])
+    )
+
+    const client = new ClaudeClient(makeConfig() as never, store as never, {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn()
+    })
+
+    const result = await client.runTurn('telegram:1', 'do something', {
+      workspace: '/tmp/workspace',
+      channel: 'telegram',
+      chatId: '1'
+    })
+
+    expect(result).toContain('error')
+  })
+
+  it('returns "Cancelled." when the query throws an abort error', async () => {
+    const { ClaudeClient } = await import('../src/core/claude-client.js')
+    const store = makeStore()
+
+    queryMock.mockReturnValue(makeThrowingQuery(new Error('AbortError: operation aborted')))
+
+    const client = new ClaudeClient(makeConfig() as never, store as never, {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn()
+    })
+
+    const result = await client.runTurn('telegram:1', 'go', {
+      workspace: '/tmp/workspace',
+      channel: 'telegram',
+      chatId: '1'
+    })
+    expect(result).toBe('Cancelled.')
+  })
+
+  it('returns an error apology when the query throws a non-abort error', async () => {
+    const { ClaudeClient } = await import('../src/core/claude-client.js')
+    const store = makeStore()
+
+    queryMock.mockReturnValue(makeThrowingQuery(new Error('rate limit exceeded')))
+
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+    const client = new ClaudeClient(makeConfig() as never, store as never, logger)
+
+    const result = await client.runTurn('telegram:1', 'go', {
+      workspace: '/tmp/workspace',
+      channel: 'telegram',
+      chatId: '1'
+    })
+    expect(result).toContain('rate limit')
+    expect(logger.error).toHaveBeenCalledWith(
+      'claude.turn_failed',
+      expect.objectContaining({ error: 'rate limit exceeded' })
+    )
+  })
+
+  it('setModel changes the model used for the next query', async () => {
+    const { ClaudeClient } = await import('../src/core/claude-client.js')
+    const store = makeStore()
+
+    queryMock.mockReturnValue(
+      makeQueryGen([
+        { type: 'result', subtype: 'success', is_error: false, result: 'ok', session_id: 's' }
+      ])
+    )
+
+    const client = new ClaudeClient(makeConfig() as never, store as never, {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn()
+    })
+
+    client.setModel('claude-haiku-4-5')
+    await client.runTurn('telegram:1', 'hi', {
+      workspace: '/tmp/workspace',
+      channel: 'telegram',
+      chatId: '1'
+    })
+
+    const [callArgs] = queryMock.mock.calls[0] as [{ options: Record<string, unknown> }]
+    expect(callArgs.options.model).toBe('claude-haiku-4-5')
+  })
+
+  it('startNewSession clears the stored session id', async () => {
+    const { ClaudeClient } = await import('../src/core/claude-client.js')
+    const store = makeStore()
+
+    const client = new ClaudeClient(makeConfig() as never, store as never, {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn()
+    })
+
+    await client.startNewSession('telegram:1')
+    expect(store.clear).toHaveBeenCalledWith('telegram:1')
+  })
+
+  it('cancelTurn aborts an in-flight turn and is a no-op otherwise', async () => {
+    const { ClaudeClient } = await import('../src/core/claude-client.js')
+    const store = makeStore()
+
+    const client = new ClaudeClient(makeConfig() as never, store as never, {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn()
+    })
+
+    // No in-flight turn — must not throw.
+    expect(() => client.cancelTurn('telegram:1')).not.toThrow()
+    expect(() => client.closeAll()).not.toThrow()
+  })
+})

--- a/tests/claude-client.test.ts
+++ b/tests/claude-client.test.ts
@@ -100,6 +100,55 @@ describe('ClaudeClient (Claude Agent SDK)', () => {
     expect(sp.append).toContain('[[memory:')
   })
 
+  it('accumulates multiple text blocks within one assistant message', async () => {
+    const { ClaudeClient } = await import('../src/core/claude-client.js')
+    const store = makeStore()
+
+    queryMock.mockReturnValue(
+      makeQueryGen([
+        {
+          type: 'assistant',
+          session_id: 'sess-multi',
+          message: {
+            content: [
+              { type: 'text', text: 'Part one. ' },
+              { type: 'text', text: 'Part two.' }
+            ]
+          }
+        },
+        {
+          type: 'result',
+          subtype: 'success',
+          is_error: false,
+          result: '',
+          session_id: 'sess-multi'
+        }
+      ])
+    )
+
+    const updates: Array<{ kind: string; text?: string }> = []
+    const onUpdate = vi.fn(async (e: { kind: string; text?: string }) => {
+      updates.push(e)
+    })
+    const client = new ClaudeClient(makeConfig() as never, store as never, {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn()
+    })
+
+    const result = await client.runTurn('telegram:1', 'go', {
+      workspace: '/tmp/workspace',
+      channel: 'telegram',
+      chatId: '1',
+      onUpdate
+    })
+
+    expect(result).toBe('Part one. Part two.')
+    // The final streaming update carries the cumulative text, not just the last block.
+    const streamed = updates.filter((u) => u.kind === 'text_streaming')
+    expect(streamed.at(-1)?.text).toBe('Part one. Part two.')
+  })
+
   it('passes resume session id when available', async () => {
     const { ClaudeClient } = await import('../src/core/claude-client.js')
     const store = {

--- a/tests/client-factory.test.ts
+++ b/tests/client-factory.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 
 import { createModelClient } from '../src/core/client-factory.js'
 import { PiClient } from '../src/core/pi-client.js'
+import { ClaudeClient } from '../src/core/claude-client.js'
 import type { PiPipeConfig } from '../src/config/schema.js'
 
 vi.mock('@earendil-works/pi-coding-agent', () => ({
@@ -19,22 +20,41 @@ vi.mock('@earendil-works/pi-ai', () => ({
   getModel: vi.fn()
 }))
 
+vi.mock('@anthropic-ai/claude-agent-sdk', () => ({
+  query: vi.fn()
+}))
+
+function makeConfig(harness: 'pi' | 'claude'): PiPipeConfig {
+  return {
+    harness,
+    model: 'claude-sonnet-4-5',
+    workspace: '/tmp',
+    transcriptLog: { enabled: false, path: '/tmp/t.jsonl' }
+  } as unknown as PiPipeConfig
+}
+
+const store = {
+  get: vi.fn(),
+  set: vi.fn(),
+  clear: vi.fn(),
+  entries: vi.fn(() => ({}))
+} as never
+const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+
 describe('createModelClient', () => {
-  it('returns a PiClient instance wired with config + store + logger', () => {
-    const config = {
-      model: 'claude-sonnet-4-5',
-      workspace: '/tmp',
-      transcriptLog: { enabled: false, path: '/tmp/t.jsonl' }
-    } as unknown as PiPipeConfig
+  it('returns a PiClient when harness is "pi"', () => {
+    const client = createModelClient(makeConfig('pi'), store, logger)
+    expect(client).toBeInstanceOf(PiClient)
+  })
 
-    const store = {
-      get: vi.fn(),
-      set: vi.fn(),
-      clear: vi.fn(),
-      entries: vi.fn(() => ({}))
-    } as never
-    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+  it('returns a ClaudeClient when harness is "claude"', () => {
+    const client = createModelClient(makeConfig('claude'), store, logger)
+    expect(client).toBeInstanceOf(ClaudeClient)
+  })
 
+  it('defaults to PiClient when harness is unset', () => {
+    const config = makeConfig('pi')
+    delete (config as { harness?: string }).harness
     const client = createModelClient(config, store, logger)
     expect(client).toBeInstanceOf(PiClient)
   })

--- a/tests/discord.test.ts
+++ b/tests/discord.test.ts
@@ -28,17 +28,31 @@ function makeConfig(overrides?: { allowChannels?: string[] }): PiPipeConfig {
 describe('DiscordChannel', () => {
   const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
 
+  // A guild text channel that satisfies the mention/history-fetch path:
+  // onMessage only publishes when the bot is mentioned (or it's a DM / bot
+  // thread), and when mentioned it fetches recent history (empty here) for
+  // context — so the channel must expose isTextBased() and messages.fetch().
+  function mentionedGuildChannel() {
+    return {
+      type: 0,
+      isTextBased: () => true,
+      messages: { fetch: vi.fn(async () => new Map()) }
+    }
+  }
+
   it('publishes inbound when sender is allowed', async () => {
     const bus = new MessageBus()
     const channel = new DiscordChannel(makeConfig(), bus, logger)
+    ;(channel as any).client = { user: { id: 'bot' } }
 
     await (channel as any).onMessage({
       author: { bot: false, id: 'u1' },
-      channel: { type: 0 },
+      channel: mentionedGuildChannel(),
       channelId: 'c1',
       content: 'hello',
       id: 'm1',
-      guildId: 'g1'
+      guildId: 'g1',
+      mentions: { has: () => true }
     })
 
     const inbound = await bus.consumeInbound()
@@ -139,6 +153,7 @@ describe('DiscordChannel', () => {
   it('processes image attachment from Discord message', async () => {
     const bus = new MessageBus()
     const channel = new DiscordChannel(makeConfig(), bus, logger)
+    ;(channel as any).client = { user: { id: 'bot' } }
 
     const mockAttachments = new Map()
     mockAttachments.set('att1', {
@@ -151,11 +166,12 @@ describe('DiscordChannel', () => {
 
     await (channel as any).onMessage({
       author: { bot: false, id: 'u1' },
-      channel: { type: 0 },
+      channel: mentionedGuildChannel(),
       channelId: 'c1',
       content: 'Look at this',
       id: 'm1',
       guildId: 'g1',
+      mentions: { has: () => true },
       attachments: mockAttachments
     })
 
@@ -285,6 +301,7 @@ describe('DiscordChannel', () => {
   it('processes multiple attachments from Discord message', async () => {
     const bus = new MessageBus()
     const channel = new DiscordChannel(makeConfig(), bus, logger)
+    ;(channel as any).client = { user: { id: 'bot' } }
 
     const mockAttachments = new Map()
     mockAttachments.set('att1', {
@@ -304,11 +321,12 @@ describe('DiscordChannel', () => {
 
     await (channel as any).onMessage({
       author: { bot: false, id: 'u1' },
-      channel: { type: 0 },
+      channel: mentionedGuildChannel(),
       channelId: 'c1',
       content: 'Check these files',
       id: 'm1',
       guildId: 'g1',
+      mentions: { has: () => true },
       attachments: mockAttachments
     })
 

--- a/tests/pi-client.test.ts
+++ b/tests/pi-client.test.ts
@@ -142,7 +142,9 @@ describe('PiClient (Pi SDK)', () => {
     expect(result).toBe('hello from pi')
     expect(sessionManagerCreateMock).toHaveBeenCalledWith('/tmp/workspace')
     expect(sessionManagerOpenMock).not.toHaveBeenCalled()
-    expect(store.set).toHaveBeenCalledWith('telegram:1', '/sessions/sess-new.jsonl')
+    expect(store.set).toHaveBeenCalledWith('telegram:1', {
+      sessionFile: '/sessions/sess-new.jsonl'
+    })
     expect(session.prompt).toHaveBeenCalledWith('hello')
   })
 
@@ -381,7 +383,9 @@ describe('PiClient (Pi SDK)', () => {
     })
 
     expect(lastLoaderOptions?.extensionFactories).toBeDefined()
-    expect(lastLoaderOptions!.extensionFactories!).toHaveLength(1)
+    // Two factories are registered: the instructions extension (index 0) and
+    // the guardrail extension (index 1).
+    expect(lastLoaderOptions!.extensionFactories!).toHaveLength(2)
 
     const factory = lastLoaderOptions!.extensionFactories![0]!
     const captured: Array<{ event: string; handler: (e: unknown) => unknown }> = []

--- a/tests/session-store.test.ts
+++ b/tests/session-store.test.ts
@@ -13,7 +13,7 @@ describe('SessionStore', () => {
 
     const store = new SessionStore(path)
     await store.init()
-    await store.set('telegram:123', '/sessions/sess-abc.jsonl')
+    await store.set('telegram:123', { sessionFile: '/sessions/sess-abc.jsonl' })
 
     const raw = JSON.parse(await readFile(path, 'utf-8')) as Record<string, { sessionFile: string }>
     expect(raw['telegram:123']?.sessionFile).toBe('/sessions/sess-abc.jsonl')
@@ -29,7 +29,7 @@ describe('SessionStore', () => {
 
     const store = new SessionStore(path)
     await store.init()
-    await store.set('telegram:123', '/sessions/sess-abc.jsonl')
+    await store.set('telegram:123', { sessionFile: '/sessions/sess-abc.jsonl' })
     await store.clear('telegram:123')
 
     expect(store.get('telegram:123')).toBeUndefined()
@@ -45,7 +45,7 @@ describe('SessionStore', () => {
 
     const store = new SessionStore(path)
     await store.init()
-    await store.set('telegram:456', '/sessions/sess-xyz.jsonl')
+    await store.set('telegram:456', { sessionFile: '/sessions/sess-xyz.jsonl' })
 
     // Lock directory should not exist after write completes
     await expect(access(lockPath)).rejects.toThrow()
@@ -60,9 +60,9 @@ describe('SessionStore', () => {
 
     // Fire multiple concurrent writes
     await Promise.all([
-      store.set('a:1', '/sessions/sess-1.jsonl'),
-      store.set('a:2', '/sessions/sess-2.jsonl'),
-      store.set('a:3', '/sessions/sess-3.jsonl')
+      store.set('a:1', { sessionFile: '/sessions/sess-1.jsonl' }),
+      store.set('a:2', { sessionFile: '/sessions/sess-2.jsonl' }),
+      store.set('a:3', { sessionFile: '/sessions/sess-3.jsonl' })
     ])
 
     // All entries should be present
@@ -81,11 +81,11 @@ describe('SessionStore', () => {
     const store = new SessionStore(path)
     await store.init()
 
-    await store.set('k1', '/p/k1.jsonl')
+    await store.set('k1', { sessionFile: '/p/k1.jsonl' })
     const snapshot = store.entries()
     expect(Object.keys(snapshot)).toEqual(['k1'])
 
-    await store.set('k2', '/p/k2.jsonl')
+    await store.set('k2', { sessionFile: '/p/k2.jsonl' })
     // The snapshot is a shallow copy — must not include the later write
     expect(Object.keys(snapshot)).toEqual(['k1'])
   })
@@ -122,7 +122,7 @@ describe('SessionStore', () => {
     await store.init()
 
     // Should succeed despite stale lock
-    await store.set('telegram:789', '/sessions/sess-stale.jsonl')
+    await store.set('telegram:789', { sessionFile: '/sessions/sess-stale.jsonl' })
     expect(store.get('telegram:789')?.sessionFile).toBe('/sessions/sess-stale.jsonl')
   })
 })

--- a/tests/wizard.test.ts
+++ b/tests/wizard.test.ts
@@ -65,6 +65,7 @@ describe('runOnboarding', () => {
   it('completes the CLI flow and writes settings.json', async () => {
     await runWithAnswers([
       '3', // CLI channel
+      '1', // harness — Pi
       '1', // Claude Haiku 4.5 preset
       workspace, // workspace path
       'TestBot', // personality name
@@ -74,6 +75,7 @@ describe('runOnboarding', () => {
     const settingsPath = join(fakeHome, '.pi-pipe', 'settings.json')
     const parsed = JSON.parse(await readFile(settingsPath, 'utf-8'))
     expect(parsed.channel).toBe('cli')
+    expect(parsed.harness).toBe('pi')
     expect(parsed.model).toBe('claude-haiku-4-5')
     expect(parsed.workspace).toBe(workspace)
     expect(parsed.personality.name).toBe('TestBot')
@@ -100,8 +102,11 @@ describe('runOnboarding', () => {
 
     // For gpt-5 (preset '3'), pressing Enter passes '' which falls through to
     // the free-form custom-model prompt — so we need an extra Enter for that.
-    // 1 channel + 1 model preset + 1 custom-model fallback + 1 workspace + 2 personality = 6
-    const updated = (await runWithAnswers(['', '', '', '', '', ''], existing)) as typeof existing
+    // 1 channel + 1 harness + 1 model preset + 1 custom-model fallback + 1 workspace + 2 personality = 7
+    const updated = (await runWithAnswers(
+      ['', '', '', '', '', '', ''],
+      existing
+    )) as typeof existing
 
     expect(updated.channel).toBe('cli')
     expect(updated.model).toBe('gpt-5')
@@ -115,7 +120,7 @@ describe('runOnboarding', () => {
     const fsp = await import('node:fs/promises')
     await fsp.writeFile(join(workspace, 'AGENTS.md'), '# Custom\n', 'utf-8')
 
-    await runWithAnswers(['3', '2', workspace, 'Bot', 'serious'])
+    await runWithAnswers(['3', '1', '2', workspace, 'Bot', 'serious'])
 
     const content = await readFile(join(workspace, 'AGENTS.md'), 'utf-8')
     expect(content).toBe('# Custom\n')
@@ -126,6 +131,7 @@ describe('runOnboarding', () => {
     // should select that without falling through to the free-form prompt.
     await runWithAnswers([
       '3', // CLI channel
+      '1', // harness — Pi
       '', // model — accept default
       workspace,
       'Pi',
@@ -147,8 +153,11 @@ describe('runOnboarding', () => {
       personality: { name: 'X', traits: 'y' }
     }
 
-    // 1 channel + 1 model preset + 1 custom-model name + 1 workspace + 2 personality = 6
-    const updated = (await runWithAnswers(['', '', '', '', '', ''], existing)) as typeof existing
+    // 1 channel + 1 harness + 1 model preset + 1 custom-model name + 1 workspace + 2 personality = 7
+    const updated = (await runWithAnswers(
+      ['', '', '', '', '', '', ''],
+      existing
+    )) as typeof existing
     expect(updated.model).toBe('something-unknown')
   })
 
@@ -157,7 +166,7 @@ describe('runOnboarding', () => {
     process.env.ANTHROPIC_API_KEY = 'sk-fake'
 
     try {
-      await runWithAnswers(['3', '1', workspace, 'X', 'snappy'])
+      await runWithAnswers(['3', '1', '1', workspace, 'X', 'snappy'])
 
       const banners = logSpy.mock.calls.map((c) => String(c[0])).join('\n')
       expect(banners).toContain('API key detected')
@@ -177,10 +186,10 @@ describe('runOnboarding', () => {
       personality: { name: 'X', traits: 'y' }
     }
 
-    // 1 channel + 1 token + 1 model preset + 1 model custom fallback +
-    // 1 workspace + 2 personality = 7 prompts
+    // 1 channel + 1 token + 1 harness + 1 model preset + 1 model custom fallback +
+    // 1 workspace + 2 personality = 8 prompts
     const updated = (await runWithAnswers(
-      ['', '', '', '', '', '', ''],
+      ['', '', '', '', '', '', '', ''],
       existing
     )) as typeof existing
     expect(updated.token).toBe('existing-token-9876')
@@ -193,7 +202,7 @@ describe('runOnboarding', () => {
     delete process.env.OPENAI_API_KEY
 
     try {
-      await runWithAnswers(['3', '1', workspace, 'X', 'snappy'])
+      await runWithAnswers(['3', '1', '1', workspace, 'X', 'snappy'])
 
       const banners = logSpy.mock.calls.map((c) => String(c[0])).join('\n')
       expect(banners).toContain('No ANTHROPIC_API_KEY')
@@ -209,6 +218,7 @@ describe('runOnboarding', () => {
     await runWithAnswers([
       '1', // telegram
       'tg-bot-token-xyz',
+      '1', // harness — Pi
       '1', // model preset
       workspace,
       'Pi',
@@ -225,7 +235,8 @@ describe('runOnboarding', () => {
     await runWithAnswers([
       '2', // discord
       'dc-bot-token-xyz',
-      '1',
+      '1', // harness — Pi
+      '1', // model preset
       workspace,
       'Pi',
       'brief'
@@ -240,6 +251,7 @@ describe('runOnboarding', () => {
   it('accepts a custom free-form model name (option 4)', async () => {
     await runWithAnswers([
       '3', // CLI channel
+      '1', // harness — Pi
       '4', // Other (free-form)
       'kimi-k2', // custom model name
       workspace,
@@ -250,5 +262,20 @@ describe('runOnboarding', () => {
     const settingsPath = join(fakeHome, '.pi-pipe', 'settings.json')
     const parsed = JSON.parse(await readFile(settingsPath, 'utf-8'))
     expect(parsed.model).toBe('kimi-k2')
+  })
+
+  it('records the Claude harness when selected', async () => {
+    await runWithAnswers([
+      '3', // CLI channel
+      '2', // harness — Claude
+      '2', // model preset (Sonnet)
+      workspace,
+      'X',
+      'snappy'
+    ])
+
+    const settingsPath = join(fakeHome, '.pi-pipe', 'settings.json')
+    const parsed = JSON.parse(await readFile(settingsPath, 'utf-8'))
+    expect(parsed.harness).toBe('claude')
   })
 })


### PR DESCRIPTION
## Summary

This PR adds support for the Claude Agent SDK as an alternative agent harness, allowing users to choose between the Pi Coding Agent SDK (multi-provider) and Claude Agent SDK (Anthropic models only) at runtime. Both harnesses now implement the same `ModelClient` interface, making them interchangeable from the rest of the application's perspective.

## Key Changes

- **New `ClaudeClient` implementation** (`src/core/claude-client.ts`): Implements the `ModelClient` interface using the Claude Agent SDK's `query()` function. Handles session resumption via `session_id`, tool call tracking, and cancellation via `AbortController`.

- **Extracted shared system prompt** (`src/core/system-prompt.ts`): Moved the base system prompt from `PiClient` into a harness-agnostic module (`buildSystemPrompt()`) so both harnesses use identical instructions and marker protocols (file attachments, keyboards, memory).

- **Harness selection in onboarding** (`src/onboarding/wizard.ts`): Added `chooseHarness()` step to the setup wizard, allowing users to select between Pi and Claude harnesses during initial configuration.

- **Factory pattern for harness instantiation** (`src/core/client-factory.ts`): Updated `createModelClient()` to instantiate either `PiClient` or `ClaudeClient` based on `config.harness`, with Pi as the default for backward compatibility.

- **Session storage abstraction** (`src/core/types.ts`, `src/core/session-store.ts`): Generalized `SessionRecord` to support both Pi's file-based sessions (`sessionFile`) and Claude's opaque session IDs (`sessionId`), allowing the store to work with either harness.

- **Configuration schema updates** (`src/config/schema.ts`, `src/config/load.ts`, `src/config/settings.ts`): Added `harness` field to the config schema with validation and environment variable support.

- **Comprehensive test coverage** (`tests/claude-client.test.ts`): Added 10 test cases covering session resumption, tool call tracking, error handling, cancellation, and model switching for the Claude harness.

- **Updated existing tests** (`tests/client-factory.test.ts`, `tests/pi-client.test.ts`, `tests/wizard.test.ts`, `tests/session-store.test.ts`): Adjusted tests to account for the new harness parameter and session storage changes.

## Notable Implementation Details

- Both harnesses emit the same `AgentTurnUpdate` events, so the agent loop and command handlers remain harness-agnostic.
- Claude's session resumption uses the `resume` option in `query()` with the persisted `session_id`.
- Tool call tracking maps `tool_use_id` to tool names to provide consistent progress updates across harnesses.
- Error handling distinguishes between abort errors (user cancellation) and other errors (API failures, rate limits).
- The system prompt is identical for both harnesses, ensuring consistent behavior regardless of which SDK is active.
- Documentation and README updated to reflect the dual-harness architecture.

https://claude.ai/code/session_012dU5E33GkcAHCJ651AshjT