### PR TITLE
Phase C: channel-layer refactors (markers, Telegram send dedup, poll timeout)

### DIFF
--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -91,6 +91,8 @@ type TelegramUpdate = {
 const TELEGRAM_MESSAGE_MAX = 3800
 const SEND_RETRY_ATTEMPTS = 2
 const SEND_RETRY_BACKOFF_MS = 50
+/** Client-side abort for getUpdates long polling (server holds ~25s). */
+const GETUPDATES_TIMEOUT_MS = 30_000
 const PID_FILE = join(tmpdir(), 'pi-pipe-telegram.pid')
 
 /** Telegram Bot API chat actions for typing indicators. */
@@ -201,41 +203,27 @@ export class TelegramChannel implements Channel {
               payload.reply_markup = this.buildInlineKeyboard(message.keyboard)
             }
 
-            const response = await fetch(url, {
-              method: 'POST',
-              headers: { 'content-type': 'application/json' },
-              body: JSON.stringify(payload)
-            })
+            const { response, usedFallback } = await this.postTelegram(
+              url,
+              payload,
+              'telegram send'
+            )
 
-            if (!response.ok) {
-              const body = await response.text()
-              // Retry without parse_mode if Markdown parsing fails
-              if (body.includes("can't parse entities")) {
-                delete payload.parse_mode
-                const fallback = await fetch(url, {
-                  method: 'POST',
-                  headers: { 'content-type': 'application/json' },
-                  body: JSON.stringify(payload)
-                })
-                if (!fallback.ok) {
-                  const fbBody = await fallback.text()
-                  throw new Error(`telegram send failed (${fallback.status}): ${fbBody}`)
+            // The fallback path already succeeded; we don't parse its body for an
+            // id (keeping behavior consistent — a Markdown-stripped resend is
+            // best-effort and not tracked for edits).
+            if (!usedFallback) {
+              try {
+                const json = (await response.json()) as {
+                  ok: boolean
+                  result?: { message_id?: number }
                 }
-                return fallback
+                if (json.ok && json.result?.message_id != null) {
+                  lastMessageId = String(json.result.message_id)
+                }
+              } catch {
+                // Message sent successfully but couldn't parse response for message ID
               }
-              throw new Error(`telegram send failed (${response.status}): ${body}`)
-            }
-
-            try {
-              const json = (await response.json()) as {
-                ok: boolean
-                result?: { message_id?: number }
-              }
-              if (json.ok && json.result?.message_id != null) {
-                lastMessageId = String(json.result.message_id)
-              }
-            } catch {
-              // Message sent successfully but couldn't parse response for message ID
             }
           },
           {
@@ -343,6 +331,42 @@ export class TelegramChannel implements Channel {
     }
   }
 
+  /**
+   * POSTs a JSON payload to a Telegram Bot API method. When the request fails
+   * with a Markdown "can't parse entities" error, it retries once without
+   * `parse_mode`. Both the initial and fallback responses are checked, so a
+   * silent send failure can't slip through. Throws on any non-recoverable
+   * failure; returns the final response plus whether the fallback path was used
+   * (callers skip message-id parsing on the fallback path).
+   */
+  private async postTelegram(
+    url: string,
+    payload: Record<string, unknown>,
+    errorLabel: string
+  ): Promise<{ response: Response; usedFallback: boolean }> {
+    const post = (): Promise<Response> =>
+      fetch(url, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(payload)
+      })
+
+    const response = await post()
+    if (response.ok) return { response, usedFallback: false }
+
+    const body = await response.text()
+    if ('parse_mode' in payload && body.includes("can't parse entities")) {
+      delete payload.parse_mode
+      const fallback = await post()
+      if (!fallback.ok) {
+        const fbBody = await fallback.text()
+        throw new Error(`${errorLabel} failed (${fallback.status}): ${fbBody}`)
+      }
+      return { response: fallback, usedFallback: true }
+    }
+    throw new Error(`${errorLabel} failed (${response.status}): ${body}`)
+  }
+
   /** Sends or updates a streaming draft message using Telegram's sendMessageDraft API. */
   async sendMessageDraft(chatId: string, text: string): Promise<SentMessage | void> {
     if (!this.config.channels.telegram.enabled) return
@@ -358,25 +382,7 @@ export class TelegramChannel implements Channel {
         parse_mode: 'Markdown'
       }
 
-      const response = await fetch(url, {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify(payload)
-      })
-
-      if (!response.ok) {
-        const body = await response.text()
-        if (body.includes("can't parse entities")) {
-          delete payload.parse_mode
-          await fetch(url, {
-            method: 'POST',
-            headers: { 'content-type': 'application/json' },
-            body: JSON.stringify(payload)
-          })
-          return
-        }
-        throw new Error(`telegram sendMessageDraft failed (${response.status}): ${body}`)
-      }
+      await this.postTelegram(url, payload, 'telegram sendMessageDraft')
     } catch (error) {
       this.logger.error('channel.telegram.draft_failed', {
         chatId,
@@ -402,30 +408,7 @@ export class TelegramChannel implements Channel {
             parse_mode: 'Markdown'
           }
 
-          const response = await fetch(url, {
-            method: 'POST',
-            headers: { 'content-type': 'application/json' },
-            body: JSON.stringify(payload)
-          })
-
-          if (!response.ok) {
-            const body = await response.text()
-            // Retry without parse_mode if Markdown parsing fails
-            if (body.includes("can't parse entities")) {
-              delete payload.parse_mode
-              const fallback = await fetch(url, {
-                method: 'POST',
-                headers: { 'content-type': 'application/json' },
-                body: JSON.stringify(payload)
-              })
-              if (!fallback.ok) {
-                const fbBody = await fallback.text()
-                throw new Error(`telegram editMessageText failed (${fallback.status}): ${fbBody}`)
-              }
-              return
-            }
-            throw new Error(`telegram editMessageText failed (${response.status}): ${body}`)
-          }
+          await this.postTelegram(url, payload, 'telegram editMessageText')
         },
         {
           attempts: SEND_RETRY_ATTEMPTS,
@@ -510,7 +493,9 @@ export class TelegramChannel implements Channel {
     url.searchParams.set('offset', String(this.nextOffset))
     url.searchParams.set('allowed_updates', JSON.stringify(['message', 'callback_query']))
 
-    const response = await fetch(url)
+    // Long polling holds the connection ~25s server-side; abort a little past
+    // that so a hung socket can't wedge the poll loop indefinitely.
+    const response = await fetch(url, { signal: AbortSignal.timeout(GETUPDATES_TIMEOUT_MS) })
     if (!response.ok) {
       const err = new Error(`Telegram getUpdates failed: ${response.status}`)
       ;(err as NodeJS.ErrnoException).code = String(response.status)

--- a/src/core/agent-loop.ts
+++ b/src/core/agent-loop.ts
@@ -7,16 +7,10 @@ import type { DailyLog } from '../memory/daily-log.js'
 import type { MemoryStore } from '../memory/store.js'
 import { applySummaryTemplate } from './prompt-template.js'
 import { MessageBus } from './bus.js'
+import { parseMarkers } from './markers.js'
 import { RateLimiter } from './rate-limiter.js'
 import type { ModelClient } from './model-client.js'
-import type {
-  AgentTurnUpdate,
-  FileAttachment,
-  InlineKeyboard,
-  InboundMessage,
-  Logger,
-  SentMessage
-} from './types.js'
+import type { AgentTurnUpdate, InboundMessage, Logger, SentMessage } from './types.js'
 
 /**
  * Converts a raw tool name into a human-readable label safe for Telegram Markdown.
@@ -249,58 +243,27 @@ export class AgentLoop {
       onUpdate: publishProgress
     })
 
-    // Extract file attachment markers from the response: [[file:/path/to/file.ext]] or [[file:/path|caption]]
-    const attachments: FileAttachment[] = []
-    let processed = rawContent.replace(
-      /\[\[file:([^|\]]+?)(?:\|([^\]]*))?\]\]/g,
-      (_match, filePath: string, caption?: string) => {
-        const trimmedPath = filePath.trim()
-        if (!this.isAttachmentPathAllowed(trimmedPath)) {
-          this.logger.warn('agent.attachment_blocked', { conversationKey, filePath: trimmedPath })
-          return ''
-        }
-        const trimmedCaption = caption?.trim()
-        attachments.push({
-          filePath: trimmedPath,
-          ...(trimmedCaption ? { caption: trimmedCaption } : {})
-        })
-        return ''
-      }
-    )
-
-    // Extract inline keyboard markers: [[keyboard:Label1=data1,Label2=data2|Label3=data3,Label4=data4]]
-    // Pipe separates rows, comma separates buttons within a row
-    let keyboard: InlineKeyboard | undefined
-    processed = processed.replace(/\[\[keyboard:([^\]]+)\]\]/g, (_match, spec: string) => {
-      const rows = spec.split('|').map((row: string) =>
-        row.split(',').map((btn: string) => {
-          const parts = btn.split('=')
-          const text = parts[0] ?? ''
-          const callbackData = parts.length > 1 ? parts.slice(1).join('=') : text.trim()
-          return { text: text.trim(), callbackData: callbackData.trim() }
-        })
-      )
-      keyboard = rows
-      return ''
+    // Parse [[file:…]] / [[keyboard:…]] / [[memory:…]] markers out of the response.
+    const {
+      text: content,
+      attachments,
+      keyboard,
+      memories
+    } = parseMarkers(rawContent, {
+      allowAttachment: (filePath) => this.isAttachmentPathAllowed(filePath),
+      onAttachmentBlocked: (filePath) =>
+        this.logger.warn('agent.attachment_blocked', { conversationKey, filePath })
     })
 
-    // Extract memory save markers: [[memory:key_name|content to remember]]
-    processed = processed.replace(
-      /\[\[memory:([^|]+)\|([^\]]+)\]\]/g,
-      (_match, key: string, value: string) => {
-        if (this.memoryStore) {
-          try {
-            this.memoryStore.save(key.trim(), value.trim())
-            this.logger.info('memory.saved', { key: key.trim() })
-          } catch (err: unknown) {
-            this.logger.warn('memory.save_failed', { key: key.trim(), error: String(err) })
-          }
-        }
-        return ''
+    for (const { key, value } of memories) {
+      if (!this.memoryStore) continue
+      try {
+        this.memoryStore.save(key, value)
+        this.logger.info('memory.saved', { key })
+      } catch (err: unknown) {
+        this.logger.warn('memory.save_failed', { key, error: String(err) })
       }
-    )
-
-    const content = processed.trim()
+    }
 
     if (attachments.length > 0) {
       this.logger.info('agent.attachments', {

--- a/src/core/markers.ts
+++ b/src/core/markers.ts
@@ -1,0 +1,89 @@
+import type { FileAttachment, InlineKeyboard } from './types.js'
+
+/**
+ * Markers the model can embed in its text response to trigger side effects:
+ *
+ * - `[[file:/path/to/file.ext]]` or `[[file:/path|caption]]` — attach a file.
+ * - `[[keyboard:Label=data,Label2=data2|Label3=data3]]` — inline keyboard
+ *   (pipe separates rows, comma separates buttons within a row).
+ * - `[[memory:key|content to remember]]` — persist a memory entry.
+ *
+ * Parsing lives here (rather than inline in the agent loop) so it can be unit
+ * tested in isolation and the loop stays focused on orchestration.
+ */
+
+const FILE_MARKER = /\[\[file:([^|\]]+?)(?:\|([^\]]*))?\]\]/g
+const KEYBOARD_MARKER = /\[\[keyboard:([^\]]+)\]\]/g
+const MEMORY_MARKER = /\[\[memory:([^|]+)\|([^\]]+)\]\]/g
+
+/** Telegram limits inline-button `callback_data` to 64 bytes. */
+const MAX_CALLBACK_DATA = 64
+
+export interface ParsedMemory {
+  key: string
+  value: string
+}
+
+export interface ParsedMarkers {
+  /** Response text with every marker removed and trimmed. */
+  text: string
+  attachments: FileAttachment[]
+  keyboard?: InlineKeyboard
+  memories: ParsedMemory[]
+}
+
+export interface ParseMarkerOptions {
+  /** Gate for file attachments (e.g. workspace containment). Defaults to allow-all. */
+  allowAttachment?: (filePath: string) => boolean
+  /** Invoked when a file marker is rejected by {@link allowAttachment}. */
+  onAttachmentBlocked?: (filePath: string) => void
+}
+
+/**
+ * Extracts file / keyboard / memory markers from a model response and returns
+ * the cleaned text alongside the structured side effects. The caller is
+ * responsible for acting on them (sending files, persisting memories, etc.).
+ */
+export function parseMarkers(raw: string, options: ParseMarkerOptions = {}): ParsedMarkers {
+  const attachments: FileAttachment[] = []
+  const memories: ParsedMemory[] = []
+  let keyboard: InlineKeyboard | undefined
+
+  let text = raw.replace(FILE_MARKER, (_match, filePath: string, caption?: string) => {
+    const trimmedPath = filePath.trim()
+    if (options.allowAttachment && !options.allowAttachment(trimmedPath)) {
+      options.onAttachmentBlocked?.(trimmedPath)
+      return ''
+    }
+    const trimmedCaption = caption?.trim()
+    attachments.push({
+      filePath: trimmedPath,
+      ...(trimmedCaption ? { caption: trimmedCaption } : {})
+    })
+    return ''
+  })
+
+  text = text.replace(KEYBOARD_MARKER, (_match, spec: string) => {
+    keyboard = spec.split('|').map((row: string) =>
+      row.split(',').map((btn: string) => {
+        const parts = btn.split('=')
+        const label = (parts[0] ?? '').trim()
+        const data = (parts.length > 1 ? parts.slice(1).join('=') : label).trim()
+        return { text: label, callbackData: data.slice(0, MAX_CALLBACK_DATA) }
+      })
+    )
+    return ''
+  })
+
+  text = text.replace(MEMORY_MARKER, (_match, key: string, value: string) => {
+    memories.push({ key: key.trim(), value: value.trim() })
+    return ''
+  })
+
+  return {
+    text: text.trim(),
+    attachments,
+    memories,
+    ...(keyboard ? { keyboard } : {})
+  }
+}

--- a/tests/markers.test.ts
+++ b/tests/markers.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi } from 'vitest'
+import { parseMarkers } from '../src/core/markers.js'
+
+describe('parseMarkers', () => {
+  it('extracts a file marker with caption and strips it from the text', () => {
+    const result = parseMarkers('Here you go: [[file:/tmp/report.pdf|monthly report]] done')
+    expect(result.attachments).toEqual([{ filePath: '/tmp/report.pdf', caption: 'monthly report' }])
+    expect(result.text).toBe('Here you go:  done')
+    expect(result.text).not.toContain('[[file:')
+  })
+
+  it('extracts a file marker without a caption', () => {
+    const result = parseMarkers('[[file:/tmp/a.png]]')
+    expect(result.attachments).toEqual([{ filePath: '/tmp/a.png' }])
+  })
+
+  it('parses inline keyboards with rows and buttons', () => {
+    const result = parseMarkers('Pick: [[keyboard:Yes=yes,No=no|Maybe=maybe]]')
+    expect(result.keyboard).toEqual([
+      [
+        { text: 'Yes', callbackData: 'yes' },
+        { text: 'No', callbackData: 'no' }
+      ],
+      [{ text: 'Maybe', callbackData: 'maybe' }]
+    ])
+  })
+
+  it('defaults callback data to the label when no "=" is present', () => {
+    const result = parseMarkers('[[keyboard:Confirm]]')
+    expect(result.keyboard).toEqual([[{ text: 'Confirm', callbackData: 'Confirm' }]])
+  })
+
+  it('truncates callback data to 64 bytes', () => {
+    const long = 'x'.repeat(100)
+    const result = parseMarkers(`[[keyboard:Go=${long}]]`)
+    expect(result.keyboard![0]![0]!.callbackData).toHaveLength(64)
+  })
+
+  it('extracts memory markers', () => {
+    const result = parseMarkers('[[memory:user_pref|likes terse replies]]')
+    expect(result.memories).toEqual([{ key: 'user_pref', value: 'likes terse replies' }])
+  })
+
+  it('handles multiple markers of each type and trims the result', () => {
+    const result = parseMarkers(
+      '  Text [[file:/a.txt]] more [[memory:k1|v1]] [[memory:k2|v2]] [[keyboard:A=a]]  '
+    )
+    expect(result.attachments).toHaveLength(1)
+    expect(result.memories).toEqual([
+      { key: 'k1', value: 'v1' },
+      { key: 'k2', value: 'v2' }
+    ])
+    expect(result.keyboard).toBeDefined()
+    expect(result.text).toBe('Text  more')
+  })
+
+  it('omits keyboard when no keyboard marker is present', () => {
+    const result = parseMarkers('plain text')
+    expect(result.keyboard).toBeUndefined()
+  })
+
+  it('blocks attachments rejected by allowAttachment and reports them', () => {
+    const onBlocked = vi.fn()
+    const result = parseMarkers('[[file:/etc/passwd]] [[file:/work/ok.txt]]', {
+      allowAttachment: (p) => p.startsWith('/work/'),
+      onAttachmentBlocked: onBlocked
+    })
+    expect(result.attachments).toEqual([{ filePath: '/work/ok.txt' }])
+    expect(onBlocked).toHaveBeenCalledWith('/etc/passwd')
+  })
+})


### PR DESCRIPTION
## Phase C — channel-layer refactors

PR 3/4. **Stacked on #28 (Phase B)** — base is the Phase B branch, so the diff shows only Phase C. Merge #27 → #28 → this. All changes are behavior-preserving and covered by the existing suite.

### Marker parsing extracted to `core/markers.ts`
The `[[file:…]]` / `[[keyboard:…]]` / `[[memory:…]]` parsing was ~50 lines of inline regex in the agent loop. It now lives in a focused, unit-tested module; the loop just acts on the structured result. Bonus correctness: inline-keyboard `callback_data` is now truncated to Telegram's 64-byte limit.

### Telegram Markdown-fallback dedup (+ bug fix)
The "can't parse entities" → resend-without-`parse_mode` fallback was copy-pasted across `send` / `sendMessageDraft` / `editMessage`. Consolidated into one `postTelegram` helper.

**Bug fixed:** `sendMessageDraft`'s fallback resend never checked its response `.ok`, so a failed retry was silently swallowed (the message just never arrived). The helper checks both the initial and fallback responses. The helper also reports whether the fallback path was taken, preserving the existing quirk that `send()` doesn't parse a message id from a Markdown-stripped resend.

### getUpdates poll timeout
`getUpdates` used a bare `fetch` with no client-side timeout; a hung socket could wedge the long-poll loop indefinitely. Added `AbortSignal.timeout(30s)` (server holds ~25s).

### Scope note
I deliberately did **not** attempt a full decomposition of the 900-line `telegram.ts` in this PR — that's a larger, riskier change better done on its own once these foundations land. This PR sticks to high-value, low-risk extractions fully protected by tests.

### Verification
- `tsc --noEmit`, `eslint`, `prettier --check` clean
- `vitest run` → **346 passed** (was 337; +9 marker tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012cuWfsWE538bEDfToqxDnY

---
_Generated by [Claude Code](https://claude.ai/code/session_012cuWfsWE538bEDfToqxDnY)_