### PR TITLE
Phase D: CI/coverage hardening, docs truthfulness, CLAUDE.md

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,9 @@ name: CI
 on:
   push:
     branches: [main]
+  # Run on every pull request, regardless of base branch, so stacked PRs are
+  # also validated (not only those targeting main).
   pull_request:
-    branches: [main]
 
 permissions:
   contents: read
@@ -14,8 +15,9 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
-        node-version: [20]
+        node-version: [20, 22]
 
     steps:
       - uses: actions/checkout@v4
@@ -38,5 +40,11 @@ jobs:
       - name: Format check
         run: npm run format:check
 
-      - name: Test
-        run: npm run test:run
+      - name: Test (with coverage thresholds)
+        run: npm run test:run -- --coverage
+
+      # Informational: surfaces dependency advisories without failing the build,
+      # since the remaining ones are transitive (discord.js -> undici/ws) and
+      # need a major upgrade to clear.
+      - name: Audit (non-blocking)
+        run: npm audit --audit-level=high || true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,64 @@
+# CLAUDE.md
+
+Guidance for AI agents and contributors working in this repository.
+
+## What this is
+
+`pi-pipe` (the npm package / product name; the GitHub repo is `claude-pipe`) is a
+local TypeScript bot that connects chat channels (Telegram, Discord, CLI) to a
+configurable agent harness — the **Pi Coding Agent SDK** (default, multi-provider)
+or the **Claude Agent SDK** (Anthropic only). Both implement one `ModelClient`
+interface, so the rest of the app is harness-agnostic.
+
+## Commands
+
+```bash
+npm install          # install deps (Node >= 20.18.1)
+npm run dev          # run from source (tsx); first run launches onboarding
+npm run build        # tsc -> dist/
+npm run test:run     # run tests once (CI uses: npm run test:run -- --coverage)
+npm run lint         # eslint
+npm run format:check # prettier check (use `npm run format` to fix)
+```
+
+Before pushing, the same gate CI runs must pass locally:
+`npx tsc --noEmit` · `npm run lint` · `npm run format:check` · `npm run test:run -- --coverage`.
+
+## Architecture (single process)
+
+```
+channels (telegram/discord/cli) → MessageBus → AgentLoop → ModelClient (Pi | Claude) → SessionStore
+```
+
+- `src/index.ts` — boot: load config, wire bus/agent/channels/heartbeat/memory.
+- `src/core/agent-loop.ts` — consumes inbound, runs one turn, parses response
+  markers, publishes replies.
+- `src/core/model-client.ts` — the harness-agnostic interface.
+- `src/core/pi-client.ts` / `claude-client.ts` — the two harness implementations.
+- `src/core/client-factory.ts` — selects the harness from `config.harness`.
+- `src/core/markers.ts` — parses `[[file:…]]` / `[[keyboard:…]]` / `[[memory:…]]`.
+- `src/core/guardrail.ts` — shared sandbox policy (blocks mutating tools +
+  sensitive reads); applied to **both** harnesses when `config.sandbox` is true.
+- `src/channels/*` — channel adapters implementing the `Channel` interface.
+- `src/config/*` — zod schema, loader (`settings.json` + `PIPIPE_*` env overrides).
+
+## Conventions
+
+- **Strict TypeScript**, ESM (`NodeNext`). Prefer no `any` in `src/` (currently
+  zero). `exactOptionalPropertyTypes` is on — include optional properties
+  conditionally (`...(x ? { x } : {})`) rather than assigning `undefined`.
+- **Tests are not typechecked** by `tsc` (the `include` is `src/**` only), so test
+  configs are partial objects cast to `never`. New runtime code that reads a
+  config field must read it defensively (optional chaining) so these partial
+  configs don't break.
+- Keep changes covered: vitest enforces coverage thresholds (see
+  `vitest.config.ts`).
+- Don't log secrets. Use the structured `logger`, not `console.*`, in runtime code.
+
+## Security model
+
+By default the agent has **full tool access** (read/write/bash) in the workspace —
+this is the personal-assistant model. Set `sandbox: true` (settings.json or
+`PIPIPE_SANDBOX=true`) to lock it down: mutating/exec tools and sensitive-path
+reads are blocked on both harnesses. An empty `allowFrom` means the channel is
+open to everyone — the bot warns about this at startup.

--- a/README.md
+++ b/README.md
@@ -155,17 +155,18 @@ Configuration is stored in `~/.pi-pipe/settings.json` and created by the onboard
 }
 ```
 
-| Setting         | What it does                                                                                                                  |
-| --------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `channel`       | Platform to use: `telegram`, `discord`, or `cli`                                                                              |
-| `token`         | Bot token from [BotFather](https://t.me/botfather) or [Discord Developer Portal](https://discord.com/developers/applications) |
-| `allowFrom`     | Array of allowed user IDs (empty = allow everyone)                                                                            |
-| `allowChannels` | Discord-only: channel ID allowlist (empty/missing = allow all channels)                                                       |
-| `harness`       | Agent harness: `pi` (Pi Coding Agent SDK, multi-provider; default) or `claude` (Claude Agent SDK, Anthropic only)             |
-| `model`         | Model name (e.g. `claude-sonnet-4-5`, `gpt-5`, `kimi-k2`, or `provider/model-id`; non-Anthropic ids require the `pi` harness) |
-| `workspace`     | Root directory the agent can access                                                                                           |
-| `personality`   | Optional: give your assistant a `name` and `traits` description                                                               |
-| `env`           | Optional: environment variables to inject at startup                                                                          |
+| Setting         | What it does                                                                                                                                           |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `channel`       | Platform to use: `telegram`, `discord`, or `cli`                                                                                                       |
+| `token`         | Bot token from [BotFather](https://t.me/botfather) or [Discord Developer Portal](https://discord.com/developers/applications)                          |
+| `allowFrom`     | Array of allowed user IDs (empty = allow everyone)                                                                                                     |
+| `allowChannels` | Discord-only: channel ID allowlist (empty/missing = allow all channels)                                                                                |
+| `harness`       | Agent harness: `pi` (Pi Coding Agent SDK, multi-provider; default) or `claude` (Claude Agent SDK, Anthropic only)                                      |
+| `sandbox`       | When `true`, lock the agent into a restricted sandbox (no shell/edit/write, no sensitive-path reads) on both harnesses. Default `false` (full access). |
+| `model`         | Model name (e.g. `claude-sonnet-4-5`, `gpt-5`, `kimi-k2`, or `provider/model-id`; non-Anthropic ids require the `pi` harness)                          |
+| `workspace`     | Root directory the agent can access                                                                                                                    |
+| `personality`   | Optional: give your assistant a `name` and `traits` description                                                                                        |
+| `env`           | Optional: environment variables to inject at startup                                                                                                   |
 
 ### Authentication
 
@@ -186,6 +187,7 @@ For options not in the settings file, use a `.env` file in `~/.pi-pipe/` or the 
 | Variable                          | What it does                                                               |
 | --------------------------------- | -------------------------------------------------------------------------- |
 | `PIPIPE_HARNESS`                  | Agent harness: `pi` (default) or `claude` (overrides the settings value)   |
+| `PIPIPE_SANDBOX`                  | `true`/`false` — restrict tools to a read-only sandbox (default `false`)   |
 | `PIPIPE_SESSION_STORE_PATH`       | Where to save session data (default: `{workspace}/data/sessions.json`)     |
 | `PIPIPE_MAX_TOOL_ITERATIONS`      | Max tool calls per turn (default: 20)                                      |
 | `PIPIPE_SUMMARY_PROMPT_ENABLED`   | Enable summary prompt templates                                            |
@@ -200,7 +202,20 @@ For options not in the settings file, use a `.env` file in `~/.pi-pipe/` or the 
 
 ### Permissions
 
-Pi runs with its default tool set (read, bash, edit, write, …) — it can read/write files and run shell commands in the workspace. Make sure your workspace is a directory you're comfortable giving full access to.
+By default the agent runs with full tool access (read, bash, edit, write, …) on
+both harnesses — it can read/write files and run shell commands in the workspace.
+Make sure your workspace is a directory you're comfortable giving full access to.
+
+**Sandbox mode.** Set `sandbox: true` in `settings.json` (or `PIPIPE_SANDBOX=true`)
+to lock the agent down: shell execution and file edits/writes are blocked, and
+reads of sensitive paths (`~/.ssh`, `~/.env`, `~/.aws`, `/etc/passwd`, the
+`pi-pipe` config dir, …) are denied. This applies to **both** the Pi and Claude
+harnesses, and is recommended for any public or shared deployment.
+
+**Access control.** `allowFrom` restricts who can talk to the bot. An empty
+`allowFrom` allows everyone — the bot logs a warning at startup when a
+network-facing channel runs wide open. Inbound messages are also rate-limited
+per sender (see `rateLimit`).
 
 ## Development
 
@@ -225,4 +240,4 @@ npm run test:run # run tests once
 ## Current limitations
 
 - Runs locally, not designed for server deployment
-- No scheduled or background tasks
+- Conversations are processed one at a time (a long-running turn blocks others)

--- a/tests/claude-client.test.ts
+++ b/tests/claude-client.test.ts
@@ -146,6 +146,52 @@ describe('ClaudeClient (Claude Agent SDK)', () => {
     expect(allowed.behavior).toBe('allow')
   })
 
+  it('reports a failed tool result when content contains an API error', async () => {
+    const { ClaudeClient } = await import('../src/core/claude-client.js')
+    const store = makeStore()
+
+    queryMock.mockReturnValue(
+      makeQueryGen([
+        {
+          type: 'assistant',
+          session_id: 's',
+          message: { content: [{ type: 'tool_use', id: 'tool-1', name: 'Bash' }] }
+        },
+        {
+          type: 'user',
+          message: {
+            content: [{ type: 'tool_result', tool_use_id: 'tool-1', content: 'API Error: boom' }]
+          }
+        },
+        {
+          type: 'result',
+          subtype: 'success',
+          is_error: false,
+          result: 'recovered',
+          session_id: 's'
+        }
+      ])
+    )
+
+    const onUpdate = vi.fn(async () => undefined)
+    const client = new ClaudeClient(makeConfig() as never, store as never, {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn()
+    })
+
+    await client.runTurn('telegram:1', 'hi', {
+      workspace: '/tmp/workspace',
+      channel: 'telegram',
+      chatId: '1',
+      onUpdate
+    })
+
+    expect(onUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 'tool_call_failed', toolName: 'Bash' })
+    )
+  })
+
   it('accumulates multiple text blocks within one assistant message', async () => {
     const { ClaudeClient } = await import('../src/core/claude-client.js')
     const store = makeStore()

--- a/tests/guardrail-extension.test.ts
+++ b/tests/guardrail-extension.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest'
+import { createGuardrailExtension } from '../src/core/guardrail-extension.js'
+import { Guardrail } from '../src/core/guardrail.js'
+
+type ToolCallResult = { block: boolean; content?: string; isError?: boolean } | undefined
+
+/** Registers the extension on a fake ExtensionAPI and returns the tool_call handler. */
+function captureHandler(): (event: unknown) => ToolCallResult {
+  const guardrail = new Guardrail({ homeDir: '/home/tester' })
+  let handler: ((event: unknown) => ToolCallResult) | undefined
+  const pi = {
+    on: (event: string, h: (event: unknown) => ToolCallResult) => {
+      if (event === 'tool_call') handler = h
+    }
+  }
+  createGuardrailExtension(guardrail)(pi as never)
+  if (!handler) throw new Error('handler not registered')
+  return handler
+}
+
+describe('createGuardrailExtension', () => {
+  it('blocks dangerous tools with an error result', () => {
+    const handler = captureHandler()
+    const result = handler({ toolName: 'bash', input: { command: 'ls' } })
+    expect(result).toMatchObject({ block: true, isError: true })
+    expect(result?.content).toContain('sandbox')
+  })
+
+  it('blocks reads of sensitive paths', () => {
+    const handler = captureHandler()
+    const result = handler({ toolName: 'read', input: { path: '/home/tester/.ssh/id_rsa' } })
+    expect(result?.block).toBe(true)
+  })
+
+  it('allows benign tool calls (returns undefined)', () => {
+    const handler = captureHandler()
+    expect(
+      handler({ toolName: 'read', input: { path: '/home/tester/work/a.txt' } })
+    ).toBeUndefined()
+  })
+
+  it('tolerates events with no toolName or input', () => {
+    const handler = captureHandler()
+    expect(handler({})).toBeUndefined()
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,7 +16,16 @@ export default defineConfig({
         // not unit tests. It would require booting every subsystem.
         'src/index.ts'
       ],
-      reporter: ['text', 'html']
+      reporter: ['text', 'html'],
+      // Guardrails against coverage regressions. Set a little below current
+      // levels (~92% stmts / ~85% branch) so normal churn doesn't trip CI but
+      // a meaningful drop does.
+      thresholds: {
+        statements: 88,
+        branches: 80,
+        functions: 92,
+        lines: 88
+      }
     }
   }
 })


### PR DESCRIPTION
## Phase D — tooling, docs & coverage

PR 4/4 (final). **Stacked on #29 (Phase C)** — base is the Phase C branch. Merge order: #27 → #28 → #29 → this.

### CI / tooling
- **Node matrix 20 → [20, 22]** (`fail-fast: false`).
- **Coverage enforced in CI**: tests run with `--coverage` and `vitest.config.ts` now sets thresholds (88% statements/lines, 80% branches, 92% functions) — set just below current (~92%/85%) so normal churn passes but a real drop fails.
- **CI now triggers on all PRs**, not only those targeting `main`, so stacked PRs are validated too (this also fixes the gap where #28/#29 wouldn't have run CI).
- Added a **non-blocking `npm audit`** step to surface advisories without failing the build on the known transitive `discord.js` ones.

### Documentation truthfulness
- **New `CLAUDE.md`**: build/test commands, architecture map, key conventions (strict TS, the "tests aren't typechecked" caveat that shapes how config is read), and the security model.
- **README**: documents `sandbox` mode + `PIPIPE_SANDBOX`; clarifies the now-**symmetric** permission posture across both harnesses; documents the open-allowlist warning and per-sender rate limiting; and fixes the stale *"No scheduled or background tasks"* limitation (the heartbeat actually runs now, after the Phase A fix).

### Tests (coverage gaps)
- Guardrail **Pi extension wrapper** — blocks dangerous tools / sensitive reads, allows benign calls, tolerates empty events (this file was ~33% covered before the Phase B refactor).
- Claude harness **failed-tool-result** branch.
- **346 → 351** tests; overall ~92% statements / ~85% branches.

### Verification
- `tsc --noEmit`, `eslint`, `prettier --check` clean
- `vitest run --coverage` → **351 passed**, thresholds satisfied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012cuWfsWE538bEDfToqxDnY

---
_Generated by [Claude Code](https://claude.ai/code/session_012cuWfsWE538bEDfToqxDnY)_