### PR TITLE
feat(discord): open a thread per session automatically

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,8 @@ PIPIPE_TELEGRAM_ALLOW_FROM=
 PIPIPE_DISCORD_ENABLED=false
 PIPIPE_DISCORD_TOKEN=
 PIPIPE_DISCORD_ALLOW_FROM=
+# Each new conversation gets its own thread (and its own session). Set to false to reply in-channel.
+PIPIPE_DISCORD_USE_THREADS=true
 
 # Optional: tuning
 PIPIPE_MAX_TOOL_ITERATIONS=20

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Configuration is stored in `~/.pi-pipe/settings.json` and created by the onboard
 | `channel`       | Platform to use: `telegram`, `discord`, or `cli`                                                                              |
 | `token`         | Bot token from [BotFather](https://t.me/botfather) or [Discord Developer Portal](https://discord.com/developers/applications) |
 | `allowFrom`     | Array of allowed user IDs (empty = allow everyone)                                                                            |
-| `allowChannels` | Discord-only: channel ID allowlist (empty/missing = allow all channels)                                                       |
+| `allowChannels` | Discord-only: channel ID allowlist (empty/missing = allow all channels); thread messages match their parent channel too       |
 | `harness`       | Agent harness: `pi` (Pi Coding Agent SDK, multi-provider; default) or `claude` (Claude Agent SDK, Anthropic only)             |
 | `model`         | Model name (e.g. `claude-sonnet-4-5`, `gpt-5`, `kimi-k2`, or `provider/model-id`; non-Anthropic ids require the `pi` harness) |
 | `workspace`     | Root directory the agent can access                                                                                           |
@@ -196,6 +196,7 @@ For options not in the settings file, use a `.env` file in `~/.pi-pipe/` or the 
 | `PIPIPE_TRANSCRIPT_LOG_MAX_FILES` | Number of rotated transcript files to keep                                 |
 | `PIPIPE_CLI_ENABLED`              | Enable CLI channel (`true`/`false`)                                        |
 | `PIPIPE_DISCORD_ALLOW_CHANNELS`   | Comma-separated allowed Discord channel IDs (empty = allow all)            |
+| `PIPIPE_DISCORD_USE_THREADS`      | Auto-create a Discord thread per session (`true`/`false`, default: `true`) |
 | `PIPIPE_CLI_ALLOW_FROM`           | Comma-separated allowed sender IDs for CLI mode                            |
 
 ### Permissions
@@ -213,6 +214,7 @@ npm run test:run # run tests once
 ## Features
 
 - **Multi-channel support**: Works with Telegram, Discord, and CLI
+- **Discord session threads**: Mentioning the bot (or running a slash command) in a text channel opens a thread and continues there. Each thread is its own session, so parallel conversations never share context, and follow-ups in the thread need no mention. Disable with `PIPIPE_DISCORD_USE_THREADS=false`.
 - **Bidirectional media attachments**: Full support for sending and receiving images, videos, documents, and audio files
   - Receive attachments from users via Telegram and Discord
   - Send attachments back to users in agent responses

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -27,6 +27,10 @@ import { isSenderAllowed, type Channel } from './base.js'
 const DISCORD_MESSAGE_MAX = 1800
 const SEND_RETRY_ATTEMPTS = 2
 const SEND_RETRY_BACKOFF_MS = 50
+/** Discord caps thread names at 100 characters. */
+const THREAD_NAME_MAX = 90
+/** One day — one of Discord's four allowed auto-archive durations. */
+const DEFAULT_THREAD_AUTO_ARCHIVE_MINUTES = 1440
 
 /**
  * Discord adapter using discord.js gateway client + channel send API.
@@ -36,6 +40,12 @@ export class DiscordChannel implements Channel {
   private client: Client | null = null
   /** Pending deferred interactions keyed by chatId, so send() can resolve them. */
   private pendingInteractions = new Map<string, ChatInputCommandInteraction>()
+  /**
+   * Threads this process opened for a session. Used so the bot keeps replying
+   * to every message in them without needing a mention, even when the gateway
+   * hands us a partial thread object without a resolvable `ownerId`.
+   */
+  private readonly ownThreadIds = new Set<string>()
 
   constructor(
     private readonly config: PiPipeConfig,
@@ -264,8 +274,12 @@ export class DiscordChannel implements Channel {
       return
     }
 
-    // Skip channel allowlist for DMs
-    if (message.channel.type !== ChannelType.DM && !this.isChannelAllowed(message.channelId)) {
+    // Skip channel allowlist for DMs. Thread messages are allowed when either
+    // the thread itself or its parent channel is on the allowlist.
+    if (
+      message.channel.type !== ChannelType.DM &&
+      !this.isChannelAllowed(message.channelId, this.parentChannelId(message.channel))
+    ) {
       this.logger.warn('channel.discord.denied_channel', {
         senderId,
         chatId: message.channelId
@@ -284,11 +298,16 @@ export class DiscordChannel implements Channel {
 
     // Only respond when mentioned, in a DM, or in a thread the bot started
     const isDM = message.channel.type === ChannelType.DM
+    const isThread =
+      message.channel.type === ChannelType.PublicThread ||
+      message.channel.type === ChannelType.PrivateThread
     const isMentioned = this.client?.user ? message.mentions.has(this.client.user) : false
     const isBotThread =
-      message.channel instanceof ThreadChannel &&
-      this.client?.user &&
-      message.channel.ownerId === this.client.user.id
+      isThread &&
+      (this.ownThreadIds.has(message.channelId) ||
+        (message.channel instanceof ThreadChannel &&
+          !!this.client?.user &&
+          message.channel.ownerId === this.client.user.id))
 
     if (!isDM && !isMentioned && !isBotThread) {
       return
@@ -300,6 +319,9 @@ export class DiscordChannel implements Channel {
       const mentionPattern = new RegExp(`<@!?${this.client.user.id}>\\s*`, 'g')
       content = content.replace(mentionPattern, '').trim() || '[empty message]'
     }
+
+    // Kept before channel context is prepended, so thread names stay readable.
+    const userText = content
 
     // Fetch last 30 messages for context when mentioned or in bot thread
     if ((isMentioned || isBotThread) && message.channel.isTextBased()) {
@@ -359,16 +381,25 @@ export class DiscordChannel implements Channel {
       }
     }
 
+    // Give every new conversation its own thread, so each thread maps to its
+    // own agent session (the conversation key is `discord:<channelId>`).
+    let chatId = message.channelId
+    if (!isDM && !isThread && this.threadsEnabled) {
+      const threadId = await this.openThread(message, this.buildThreadName(userText))
+      if (threadId) chatId = threadId
+    }
+
     const inbound: InboundMessage = {
       channel: 'discord',
       senderId,
-      chatId: message.channelId,
+      chatId,
       content,
       timestamp: new Date().toISOString(),
       ...(attachments.length > 0 ? { attachments } : {}),
       metadata: {
         messageId: message.id,
-        guildId: message.guildId ?? undefined
+        guildId: message.guildId ?? undefined,
+        ...(chatId !== message.channelId ? { parentChannelId: message.channelId } : {})
       }
     }
 
@@ -393,7 +424,7 @@ export class DiscordChannel implements Channel {
     // Skip channel allowlist for DMs
     if (
       interaction.channel?.type !== ChannelType.DM &&
-      !this.isChannelAllowed(interaction.channelId)
+      !this.isChannelAllowed(interaction.channelId, this.parentChannelId(interaction.channel))
     ) {
       this.logger.warn('channel.discord.denied_channel', {
         senderId,
@@ -412,26 +443,143 @@ export class DiscordChannel implements Channel {
     const content = promptOption ? `${commandName} ${promptOption}` : commandName
 
     await interaction.deferReply()
-    this.pendingInteractions.set(interaction.channelId, interaction)
+
+    // Slash commands invoked in a regular text channel also get their own
+    // thread; the deferred reply becomes the thread starter message.
+    let chatId = interaction.channelId
+    if (interaction.channel?.type === ChannelType.GuildText && this.threadsEnabled) {
+      const threadId = await this.openInteractionThread(interaction, this.buildThreadName(content))
+      if (threadId) chatId = threadId
+    }
+
+    // Only resolve the deferred reply in place when the answer stays in this
+    // channel — otherwise the response is delivered to the new thread.
+    if (chatId === interaction.channelId) {
+      this.pendingInteractions.set(interaction.channelId, interaction)
+    }
 
     const inbound: InboundMessage = {
       channel: 'discord',
       senderId,
-      chatId: interaction.channelId,
+      chatId,
       content,
       timestamp: new Date().toISOString(),
       metadata: {
         interactionId: interaction.id,
-        guildId: interaction.guildId ?? undefined
+        guildId: interaction.guildId ?? undefined,
+        ...(chatId !== interaction.channelId ? { parentChannelId: interaction.channelId } : {})
       }
     }
 
     await this.bus.publishInbound(inbound)
   }
 
-  private isChannelAllowed(chatId: string): boolean {
+  /** True unless threads are explicitly disabled in config. */
+  private get threadsEnabled(): boolean {
+    return this.config.channels.discord.useThreads !== false
+  }
+
+  private get threadAutoArchiveMinutes(): number {
+    return (
+      this.config.channels.discord.threadAutoArchiveMinutes ?? DEFAULT_THREAD_AUTO_ARCHIVE_MINUTES
+    )
+  }
+
+  /** Reads the parent channel id of a thread, when the channel exposes one. */
+  private parentChannelId(channel: unknown): string | undefined {
+    if (channel && typeof channel === 'object' && 'parentId' in channel) {
+      const parentId = (channel as { parentId?: string | null }).parentId
+      return parentId ?? undefined
+    }
+    return undefined
+  }
+
+  /** Derives a readable thread name from the first line of the user's message. */
+  private buildThreadName(content: string): string {
+    const cleaned = content
+      .replace(/<@!?\d+>/g, '')
+      .split('\n')
+      .map((line) => line.trim())
+      .find((line) => line.length > 0)
+      ?.replace(/\s+/g, ' ')
+
+    if (!cleaned) return 'New session'
+    return cleaned.length > THREAD_NAME_MAX ? `${cleaned.slice(0, THREAD_NAME_MAX - 1)}…` : cleaned
+  }
+
+  /**
+   * Opens (or reuses) a thread anchored on the triggering message.
+   *
+   * Returns the thread id, or null when the thread could not be created —
+   * e.g. missing "Create Public Threads" permission — so the caller can fall
+   * back to replying in the parent channel.
+   */
+  private async openThread(message: Message, name: string): Promise<string | null> {
+    try {
+      if (message.hasThread && message.thread) {
+        this.ownThreadIds.add(message.thread.id)
+        return message.thread.id
+      }
+      if (typeof message.startThread !== 'function') return null
+
+      const thread = await message.startThread({
+        name,
+        autoArchiveDuration: this.threadAutoArchiveMinutes
+      })
+      this.ownThreadIds.add(thread.id)
+      this.logger.info('channel.discord.thread_created', {
+        threadId: thread.id,
+        parentId: message.channelId,
+        name
+      })
+      return thread.id
+    } catch (error) {
+      this.logger.warn('channel.discord.thread_create_failed', {
+        chatId: message.channelId,
+        error: error instanceof Error ? error.message : String(error)
+      })
+      return null
+    }
+  }
+
+  /**
+   * Opens a thread anchored on a slash command's deferred reply and points the
+   * user at it. Returns null when the thread could not be created.
+   */
+  private async openInteractionThread(
+    interaction: ChatInputCommandInteraction,
+    name: string
+  ): Promise<string | null> {
+    try {
+      if (typeof interaction.fetchReply !== 'function') return null
+      const reply = await interaction.fetchReply()
+      if (!reply || typeof reply.startThread !== 'function') return null
+
+      const thread = await reply.startThread({
+        name,
+        autoArchiveDuration: this.threadAutoArchiveMinutes
+      })
+      this.ownThreadIds.add(thread.id)
+      await interaction.editReply({ content: `🧵 Continuing in <#${thread.id}>` })
+      this.logger.info('channel.discord.thread_created', {
+        threadId: thread.id,
+        parentId: interaction.channelId,
+        name
+      })
+      return thread.id
+    } catch (error) {
+      this.logger.warn('channel.discord.thread_create_failed', {
+        chatId: interaction.channelId,
+        error: error instanceof Error ? error.message : String(error)
+      })
+      return null
+    }
+  }
+
+  private isChannelAllowed(chatId: string, parentId?: string): boolean {
     const allowChannels = this.config.channels.discord.allowChannels ?? []
-    return allowChannels.length === 0 || allowChannels.includes(chatId)
+    if (allowChannels.length === 0) return true
+    return allowChannels.includes(chatId) || (parentId != null && allowChannels.includes(parentId))
   }
 
   /**

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -13,6 +13,12 @@ function parseCsv(input: string | undefined): string[] {
     .filter(Boolean)
 }
 
+/** Parses an optional boolean env value, leaving it unset when absent. */
+function parseOptionalBool(input: string | undefined): boolean | undefined {
+  if (input === undefined || input === '') return undefined
+  return input === 'true'
+}
+
 /** Normalizes a harness string, falling back to 'pi' for unknown/missing values. */
 function parseHarness(input: string | undefined): 'pi' | 'claude' {
   return input === 'claude' ? 'claude' : 'pi'
@@ -64,7 +70,10 @@ export function loadConfig(): PiPipeConfig {
           enabled: discordEnabled,
           token: discordEnabled ? s.token : '',
           allowFrom: discordEnabled ? s.allowFrom : [],
-          allowChannels: discordEnabled ? s.allowChannels : undefined
+          allowChannels: discordEnabled ? s.allowChannels : undefined,
+          useThreads: discordEnabled
+            ? parseOptionalBool(process.env.PIPIPE_DISCORD_USE_THREADS)
+            : undefined
         },
         cli: {
           enabled: cliEnabled || process.env.PIPIPE_CLI_ENABLED === 'true',
@@ -95,7 +104,8 @@ export function loadConfig(): PiPipeConfig {
         enabled: process.env.PIPIPE_DISCORD_ENABLED === 'true',
         token: process.env.PIPIPE_DISCORD_TOKEN ?? '',
         allowFrom: parseCsv(process.env.PIPIPE_DISCORD_ALLOW_FROM),
-        allowChannels: parseCsv(process.env.PIPIPE_DISCORD_ALLOW_CHANNELS)
+        allowChannels: parseCsv(process.env.PIPIPE_DISCORD_ALLOW_CHANNELS),
+        useThreads: parseOptionalBool(process.env.PIPIPE_DISCORD_USE_THREADS)
       },
       cli: {
         enabled: process.env.PIPIPE_CLI_ENABLED === 'true',

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -8,7 +8,15 @@ const channelSchema = z.object({
 
 const discordChannelSchema = channelSchema.extend({
   // Optional allowlist of Discord channel IDs. Empty/omitted means allow all channels.
-  allowChannels: z.array(z.string()).optional()
+  // Thread messages are matched against the thread's parent channel too.
+  allowChannels: z.array(z.string()).optional(),
+  // Automatically open a Discord thread per conversation so every session gets
+  // its own thread (and therefore its own agent session). Defaults to enabled.
+  useThreads: z.boolean().optional(),
+  // Discord only accepts these four auto-archive durations (minutes).
+  threadAutoArchiveMinutes: z
+    .union([z.literal(60), z.literal(1440), z.literal(4320), z.literal(10080)])
+    .optional()
 })
 
 const cliChannelSchema = z.object({

--- a/tests/discord-threads.test.ts
+++ b/tests/discord-threads.test.ts
@@ -1,0 +1,321 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { DiscordChannel } from '../src/channels/discord.js'
+import { MessageBus } from '../src/core/bus.js'
+import type { PiPipeConfig } from '../src/config/schema.js'
+
+const GUILD_TEXT = 0
+const PUBLIC_THREAD = 11
+
+function makeConfig(overrides?: {
+  allowChannels?: string[]
+  useThreads?: boolean
+  threadAutoArchiveMinutes?: 60 | 1440 | 4320 | 10080
+}): PiPipeConfig {
+  return {
+    model: 'claude-sonnet-4-5',
+    workspace: '/tmp/workspace',
+    channels: {
+      telegram: { enabled: false, token: '', allowFrom: [] },
+      discord: {
+        enabled: true,
+        token: 'discord-token',
+        allowFrom: ['u1'],
+        allowChannels: overrides?.allowChannels,
+        useThreads: overrides?.useThreads,
+        threadAutoArchiveMinutes: overrides?.threadAutoArchiveMinutes
+      }
+    },
+    summaryPrompt: { enabled: true, template: 'Workspace: {{workspace}} Request: {{request}}' },
+    transcriptLog: { enabled: false, path: '/tmp/transcript.jsonl' },
+    sessionStorePath: '/tmp/sessions.json',
+    maxToolIterations: 20
+  } as unknown as PiPipeConfig
+}
+
+/** A guild text channel that supports the history fetch done on mention. */
+function guildChannel() {
+  return {
+    type: GUILD_TEXT,
+    isTextBased: () => true,
+    messages: { fetch: vi.fn(async () => new Map()) }
+  }
+}
+
+function threadChannel(parentId: string) {
+  return {
+    type: PUBLIC_THREAD,
+    parentId,
+    isTextBased: () => true,
+    messages: { fetch: vi.fn(async () => new Map()) }
+  }
+}
+
+const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+
+type OnMessage = { onMessage: (m: unknown) => Promise<void> }
+type OnInteraction = { onInteraction: (i: unknown) => Promise<void> }
+
+describe('DiscordChannel session threads', () => {
+  it('opens a thread for a mention in a text channel and routes the session there', async () => {
+    const bus = new MessageBus()
+    const channel = new DiscordChannel(makeConfig(), bus, logger)
+    ;(channel as unknown as { client: unknown }).client = { user: { id: 'bot' } }
+
+    const startThread = vi.fn(async () => ({ id: 'thread-1' }))
+
+    await (channel as unknown as OnMessage).onMessage({
+      author: { bot: false, id: 'u1' },
+      channel: guildChannel(),
+      channelId: 'c1',
+      content: '<@bot> plan the migration',
+      id: 'm1',
+      guildId: 'g1',
+      mentions: { has: () => true },
+      startThread
+    })
+
+    expect(startThread).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'plan the migration', autoArchiveDuration: 1440 })
+    )
+
+    const inbound = await bus.consumeInbound()
+    expect(inbound.chatId).toBe('thread-1')
+    expect(inbound.metadata?.parentChannelId).toBe('c1')
+  })
+
+  it('honours a configured auto-archive duration', async () => {
+    const bus = new MessageBus()
+    const channel = new DiscordChannel(makeConfig({ threadAutoArchiveMinutes: 60 }), bus, logger)
+    ;(channel as unknown as { client: unknown }).client = { user: { id: 'bot' } }
+
+    const startThread = vi.fn(async () => ({ id: 'thread-1' }))
+
+    await (channel as unknown as OnMessage).onMessage({
+      author: { bot: false, id: 'u1' },
+      channel: guildChannel(),
+      channelId: 'c1',
+      content: 'hi',
+      id: 'm1',
+      guildId: 'g1',
+      mentions: { has: () => true },
+      startThread
+    })
+
+    expect(startThread).toHaveBeenCalledWith(expect.objectContaining({ autoArchiveDuration: 60 }))
+    await bus.consumeInbound()
+  })
+
+  it('reuses the thread already attached to the message', async () => {
+    const bus = new MessageBus()
+    const channel = new DiscordChannel(makeConfig(), bus, logger)
+    ;(channel as unknown as { client: unknown }).client = { user: { id: 'bot' } }
+
+    const startThread = vi.fn()
+
+    await (channel as unknown as OnMessage).onMessage({
+      author: { bot: false, id: 'u1' },
+      channel: guildChannel(),
+      channelId: 'c1',
+      content: 'again',
+      id: 'm1',
+      guildId: 'g1',
+      mentions: { has: () => true },
+      hasThread: true,
+      thread: { id: 'thread-existing' },
+      startThread
+    })
+
+    expect(startThread).not.toHaveBeenCalled()
+    const inbound = await bus.consumeInbound()
+    expect(inbound.chatId).toBe('thread-existing')
+  })
+
+  it('falls back to the parent channel when thread creation fails', async () => {
+    const bus = new MessageBus()
+    const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+    const channel = new DiscordChannel(makeConfig(), bus, log)
+    ;(channel as unknown as { client: unknown }).client = { user: { id: 'bot' } }
+
+    await (channel as unknown as OnMessage).onMessage({
+      author: { bot: false, id: 'u1' },
+      channel: guildChannel(),
+      channelId: 'c1',
+      content: 'hello',
+      id: 'm1',
+      guildId: 'g1',
+      mentions: { has: () => true },
+      startThread: vi.fn(async () => {
+        throw new Error('Missing Permissions')
+      })
+    })
+
+    const inbound = await bus.consumeInbound()
+    expect(inbound.chatId).toBe('c1')
+    expect(inbound.metadata?.parentChannelId).toBeUndefined()
+    expect(log.warn).toHaveBeenCalledWith(
+      'channel.discord.thread_create_failed',
+      expect.objectContaining({ chatId: 'c1' })
+    )
+  })
+
+  it('does not create threads when useThreads is disabled', async () => {
+    const bus = new MessageBus()
+    const channel = new DiscordChannel(makeConfig({ useThreads: false }), bus, logger)
+    ;(channel as unknown as { client: unknown }).client = { user: { id: 'bot' } }
+
+    const startThread = vi.fn(async () => ({ id: 'thread-1' }))
+
+    await (channel as unknown as OnMessage).onMessage({
+      author: { bot: false, id: 'u1' },
+      channel: guildChannel(),
+      channelId: 'c1',
+      content: 'hello',
+      id: 'm1',
+      guildId: 'g1',
+      mentions: { has: () => true },
+      startThread
+    })
+
+    expect(startThread).not.toHaveBeenCalled()
+    const inbound = await bus.consumeInbound()
+    expect(inbound.chatId).toBe('c1')
+  })
+
+  it('replies to follow-ups in its own thread without a mention', async () => {
+    const bus = new MessageBus()
+    const channel = new DiscordChannel(makeConfig(), bus, logger)
+    ;(channel as unknown as { client: unknown }).client = { user: { id: 'bot' } }
+
+    await (channel as unknown as OnMessage).onMessage({
+      author: { bot: false, id: 'u1' },
+      channel: guildChannel(),
+      channelId: 'c1',
+      content: '<@bot> start',
+      id: 'm1',
+      guildId: 'g1',
+      mentions: { has: () => true },
+      startThread: vi.fn(async () => ({ id: 'thread-1' }))
+    })
+    await bus.consumeInbound()
+
+    await (channel as unknown as OnMessage).onMessage({
+      author: { bot: false, id: 'u1' },
+      channel: threadChannel('c1'),
+      channelId: 'thread-1',
+      content: 'follow-up',
+      id: 'm2',
+      guildId: 'g1',
+      mentions: { has: () => false }
+    })
+
+    const inbound = await bus.consumeInbound()
+    expect(inbound.chatId).toBe('thread-1')
+    expect(inbound.content).toContain('follow-up')
+  })
+
+  it('allows thread messages when only the parent channel is allowlisted', async () => {
+    const bus = new MessageBus()
+    const channel = new DiscordChannel(makeConfig({ allowChannels: ['c1'] }), bus, logger)
+    ;(channel as unknown as { client: unknown }).client = { user: { id: 'bot' } }
+
+    await (channel as unknown as OnMessage).onMessage({
+      author: { bot: false, id: 'u1' },
+      channel: threadChannel('c1'),
+      channelId: 'thread-unknown',
+      content: '<@bot> in a thread',
+      id: 'm1',
+      guildId: 'g1',
+      mentions: { has: () => true }
+    })
+
+    const inbound = await bus.consumeInbound()
+    expect(inbound.chatId).toBe('thread-unknown')
+  })
+
+  it('truncates long thread names to Discord limits', async () => {
+    const bus = new MessageBus()
+    const channel = new DiscordChannel(makeConfig(), bus, logger)
+    ;(channel as unknown as { client: unknown }).client = { user: { id: 'bot' } }
+
+    const startThread = vi.fn(async () => ({ id: 'thread-1' }))
+
+    await (channel as unknown as OnMessage).onMessage({
+      author: { bot: false, id: 'u1' },
+      channel: guildChannel(),
+      channelId: 'c1',
+      content: 'x'.repeat(200),
+      id: 'm1',
+      guildId: 'g1',
+      mentions: { has: () => true },
+      startThread
+    })
+
+    const name = startThread.mock.calls[0]?.[0]?.name as string
+    expect(name.length).toBeLessThanOrEqual(100)
+    await bus.consumeInbound()
+  })
+
+  it('opens a thread for slash commands and points the reply at it', async () => {
+    const bus = new MessageBus()
+    const channel = new DiscordChannel(makeConfig(), bus, logger)
+
+    const startThread = vi.fn(async () => ({ id: 'thread-9' }))
+    const editReply = vi.fn(async () => undefined)
+    const interaction = {
+      user: { id: 'u1' },
+      channelId: 'c1',
+      channel: { type: GUILD_TEXT },
+      options: { getSubcommand: () => 'new', getString: () => null },
+      commandName: 'session',
+      deferReply: vi.fn(async () => undefined),
+      fetchReply: vi.fn(async () => ({ startThread })),
+      editReply,
+      id: 'i1',
+      guildId: 'g1'
+    }
+
+    await (channel as unknown as OnInteraction).onInteraction(interaction)
+
+    expect(startThread).toHaveBeenCalled()
+    expect(editReply).toHaveBeenCalledWith({ content: '🧵 Continuing in <#thread-9>' })
+    // The answer goes to the thread, so the deferred reply is not reused.
+    expect(
+      (channel as unknown as { pendingInteractions: Map<string, unknown> }).pendingInteractions.size
+    ).toBe(0)
+
+    const inbound = await bus.consumeInbound()
+    expect(inbound.chatId).toBe('thread-9')
+    expect(inbound.content).toBe('/session_new')
+  })
+
+  it('keeps resolving the deferred reply when the slash command thread fails', async () => {
+    const bus = new MessageBus()
+    const channel = new DiscordChannel(makeConfig(), bus, { ...logger, warn: vi.fn() })
+
+    const interaction = {
+      user: { id: 'u1' },
+      channelId: 'c1',
+      channel: { type: GUILD_TEXT },
+      options: { getSubcommand: () => null, getString: () => null },
+      commandName: 'ping',
+      deferReply: vi.fn(async () => undefined),
+      fetchReply: vi.fn(async () => {
+        throw new Error('Unknown Message')
+      }),
+      editReply: vi.fn(async () => undefined),
+      id: 'i1',
+      guildId: 'g1'
+    }
+
+    await (channel as unknown as OnInteraction).onInteraction(interaction)
+
+    const inbound = await bus.consumeInbound()
+    expect(inbound.chatId).toBe('c1')
+    expect(
+      (channel as unknown as { pendingInteractions: Map<string, unknown> }).pendingInteractions.get(
+        'c1'
+      )
+    ).toBe(interaction)
+  })
+})


### PR DESCRIPTION
## What

Discord conversations now get their own thread automatically. Mentioning the bot in a guild text channel starts a thread anchored on that message and continues there; slash commands do the same from their deferred reply (the reply is edited to point at the thread).

Because the conversation key is `discord:<channelId>` and a thread has its own channel id, **each thread is its own agent session** — parallel conversations in the same channel no longer share context. That part of the wiring was already there; what was missing was actually creating the threads.

## Changes

- `src/channels/discord.ts`
  - `openThread()` — starts (or reuses) a thread on the triggering message; inbound is published with `chatId = threadId` and `metadata.parentChannelId`.
  - `openInteractionThread()` — same for slash commands, via `interaction.fetchReply().startThread()`; the deferred reply is only resolved in place when no thread was opened.
  - Thread names come from the first line of the user's message (mention stripped, truncated to Discord's limit).
  - Follow-ups in a bot-opened thread are answered without a mention — tracked by thread id, so partial thread objects without a resolvable `ownerId` still match.
  - The channel allowlist now also matches a thread's parent channel, so threads under an allowed channel are no longer silently dropped.
  - Thread creation failures (e.g. missing "Create Public Threads") log a warning and fall back to replying in the parent channel.
- `src/config/schema.ts`, `src/config/load.ts` — new optional `useThreads` and `threadAutoArchiveMinutes` Discord settings, plus a `PIPIPE_DISCORD_USE_THREADS` env override. Threads are on by default; auto-archive defaults to 24h.
- Docs: README settings/env tables and feature list, `.env.example`.

## Testing

- `tests/discord-threads.test.ts` (new, 9 cases): thread creation and routing, thread reuse, configurable auto-archive, name truncation, permission-failure fallback, `useThreads: false`, unmentioned follow-ups in a bot thread, parent-channel allowlisting, and both slash-command paths.
- Full suite: 329 tests pass; `npm run build`, `npm run lint`, and `prettier --check` are clean.

## Notes

The bot needs the "Create Public Threads" permission in channels where it is used; without it, behavior is unchanged from before (replies land in the channel) and a `channel.discord.thread_create_failed` warning is logged.

---
_Generated by [Claude Code](https://claude.ai/code/session_017s2aUdUDfKLnfFNZ4VjZP1)_