### PR TITLE
Fix Discord context management: seed history only when a thread starts

### DIFF
--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -46,6 +46,12 @@ export class DiscordChannel implements Channel {
    * hands us a partial thread object without a resolvable `ownerId`.
    */
   private readonly ownThreadIds = new Set<string>()
+  /**
+   * Conversations that already received a channel-history context block.
+   * Each thread maps to a persistent agent session, so surrounding history is
+   * sent once when the conversation starts — never re-sent on follow-ups.
+   */
+  private readonly seededChatIds = new Set<string>()
 
   constructor(
     private readonly config: PiPipeConfig,
@@ -323,28 +329,31 @@ export class DiscordChannel implements Channel {
     // Kept before channel context is prepended, so thread names stay readable.
     const userText = content
 
-    // Fetch last 30 messages for context when mentioned or in bot thread
-    if ((isMentioned || isBotThread) && message.channel.isTextBased()) {
-      try {
-        const messages = await message.channel.messages.fetch({
-          limit: 30,
-          before: message.id
-        })
-        const history = Array.from(messages.values())
-          .reverse()
-          .map((m) => {
-            const author = m.author.username
-            const text = m.content?.trim() || ''
-            return text ? `${author}: ${text}` : null
-          })
-          .filter(Boolean)
-          .join('\n')
+    // Give every new conversation its own thread, so each thread maps to its
+    // own agent session (the conversation key is `discord:<chatId>`).
+    let chatId = message.channelId
+    let openedNewThread = false
+    if (!isDM && !isThread && this.threadsEnabled) {
+      const hadThread = message.hasThread && !!message.thread
+      const threadId = await this.openThread(message, this.buildThreadName(userText))
+      if (threadId) {
+        chatId = threadId
+        openedNewThread = !hadThread
+      }
+    }
 
-        if (history) {
-          content = `[Channel context — last 30 messages]:\n${history}\n\n[Current message]:\n${content}`
-        }
-      } catch {
-        // Silently fail if we can't fetch history
+    // Seed channel history once, only when a thread conversation starts:
+    // either a fresh thread opened off a mention (context = the surrounding
+    // parent-channel messages) or the first mention in an existing thread the
+    // bot does not own (context = the thread so far). Follow-ups in bot
+    // threads never re-send history — the agent session already has it.
+    const startsForeignThreadConversation =
+      isThread && isMentioned && !isBotThread && !this.seededChatIds.has(chatId)
+    if ((openedNewThread || startsForeignThreadConversation) && message.channel.isTextBased()) {
+      this.seededChatIds.add(chatId)
+      const history = await this.fetchHistoryContext(message)
+      if (history) {
+        content = `[Channel context — recent messages]:\n${history}\n\n[Current message]:\n${content}`
       }
     }
 
@@ -379,14 +388,6 @@ export class DiscordChannel implements Channel {
           size: attachment.size
         })
       }
-    }
-
-    // Give every new conversation its own thread, so each thread maps to its
-    // own agent session (the conversation key is `discord:<channelId>`).
-    let chatId = message.channelId
-    if (!isDM && !isThread && this.threadsEnabled) {
-      const threadId = await this.openThread(message, this.buildThreadName(userText))
-      if (threadId) chatId = threadId
     }
 
     const inbound: InboundMessage = {
@@ -492,6 +493,33 @@ export class DiscordChannel implements Channel {
       return parentId ?? undefined
     }
     return undefined
+  }
+
+  /**
+   * Fetches the messages preceding the triggering one and formats them as a
+   * one-shot context block. The bot's own messages are excluded — they came
+   * out of an agent session and would only duplicate what a session already
+   * knows. Returns an empty string when there is no usable history.
+   */
+  private async fetchHistoryContext(message: Message): Promise<string> {
+    try {
+      const messages = await message.channel.messages.fetch({
+        limit: 30,
+        before: message.id
+      })
+      return Array.from(messages.values())
+        .reverse()
+        .filter((m) => m.author.id !== this.client?.user?.id)
+        .map((m) => {
+          const text = m.content?.trim() || ''
+          return text ? `${m.author.username}: ${text}` : null
+        })
+        .filter(Boolean)
+        .join('\n')
+    } catch {
+      // Missing history is not fatal — the current message still goes through.
+      return ''
+    }
   }
 
   /** Derives a readable thread name from the first line of the user's message. */

--- a/tests/discord-threads.test.ts
+++ b/tests/discord-threads.test.ts
@@ -256,6 +256,117 @@ describe('DiscordChannel session threads', () => {
     await bus.consumeInbound()
   })
 
+  it('seeds parent-channel history once when opening a new thread, excluding bot messages', async () => {
+    const bus = new MessageBus()
+    const channel = new DiscordChannel(makeConfig(), bus, logger)
+    ;(channel as unknown as { client: unknown }).client = { user: { id: 'bot' } }
+
+    // Discord returns history newest-first; onMessage reverses it.
+    const history = new Map([
+      ['h2', { author: { id: 'u2', username: 'bob' }, content: 'second' }],
+      ['hbot', { author: { id: 'bot', username: 'pipe' }, content: 'bot reply' }],
+      ['h1', { author: { id: 'u1', username: 'alice' }, content: 'first' }]
+    ])
+    const fetch = vi.fn(async () => history)
+
+    await (channel as unknown as OnMessage).onMessage({
+      author: { bot: false, id: 'u1' },
+      channel: { type: GUILD_TEXT, isTextBased: () => true, messages: { fetch } },
+      channelId: 'c1',
+      content: '<@bot> summarise this',
+      id: 'm1',
+      guildId: 'g1',
+      mentions: { has: () => true },
+      startThread: vi.fn(async () => ({ id: 'thread-ctx' }))
+    })
+
+    const inbound = await bus.consumeInbound()
+    expect(fetch).toHaveBeenCalledWith({ limit: 30, before: 'm1' })
+    expect(inbound.content).toContain('alice: first')
+    expect(inbound.content).toContain('bob: second')
+    expect(inbound.content).not.toContain('bot reply')
+    expect(inbound.content).toContain('[Current message]:\nsummarise this')
+  })
+
+  it('does not re-send history for follow-ups in its own thread', async () => {
+    const bus = new MessageBus()
+    const channel = new DiscordChannel(makeConfig(), bus, logger)
+    ;(channel as unknown as { client: unknown }).client = { user: { id: 'bot' } }
+
+    await (channel as unknown as OnMessage).onMessage({
+      author: { bot: false, id: 'u1' },
+      channel: guildChannel(),
+      channelId: 'c1',
+      content: '<@bot> start',
+      id: 'm1',
+      guildId: 'g1',
+      mentions: { has: () => true },
+      startThread: vi.fn(async () => ({ id: 'thread-1' }))
+    })
+    await bus.consumeInbound()
+
+    const threadFetch = vi.fn(async () => new Map())
+    await (channel as unknown as OnMessage).onMessage({
+      author: { bot: false, id: 'u1' },
+      channel: {
+        type: PUBLIC_THREAD,
+        parentId: 'c1',
+        isTextBased: () => true,
+        messages: { fetch: threadFetch }
+      },
+      channelId: 'thread-1',
+      content: 'follow-up',
+      id: 'm2',
+      guildId: 'g1',
+      mentions: { has: () => false }
+    })
+
+    const inbound = await bus.consumeInbound()
+    expect(threadFetch).not.toHaveBeenCalled()
+    expect(inbound.content).toBe('follow-up')
+  })
+
+  it('seeds a foreign thread only on the first mention', async () => {
+    const bus = new MessageBus()
+    const channel = new DiscordChannel(makeConfig(), bus, logger)
+    ;(channel as unknown as { client: unknown }).client = { user: { id: 'bot' } }
+
+    const fetch = vi.fn(
+      async () => new Map([['h1', { author: { id: 'u2', username: 'carol' }, content: 'earlier' }]])
+    )
+    const foreignThread = {
+      type: PUBLIC_THREAD,
+      parentId: 'c1',
+      isTextBased: () => true,
+      messages: { fetch }
+    }
+
+    await (channel as unknown as OnMessage).onMessage({
+      author: { bot: false, id: 'u1' },
+      channel: foreignThread,
+      channelId: 'thread-foreign',
+      content: '<@bot> first ping',
+      id: 'm1',
+      guildId: 'g1',
+      mentions: { has: () => true }
+    })
+    const first = await bus.consumeInbound()
+    expect(first.content).toContain('carol: earlier')
+
+    await (channel as unknown as OnMessage).onMessage({
+      author: { bot: false, id: 'u1' },
+      channel: foreignThread,
+      channelId: 'thread-foreign',
+      content: '<@bot> second ping',
+      id: 'm2',
+      guildId: 'g1',
+      mentions: { has: () => true }
+    })
+    const second = await bus.consumeInbound()
+    expect(fetch).toHaveBeenCalledTimes(1)
+    expect(second.content).toBe('second ping')
+  })
+
   it('opens a thread for slash commands and points the reply at it', async () => {
     const bus = new MessageBus()
     const channel = new DiscordChannel(makeConfig(), bus, logger)


### PR DESCRIPTION
## Problem

Every mention and every message in a bot thread re-fetched the last 30 channel messages and prepended them to the prompt. Since each Discord thread already maps to a persistent agent session (`discord:<threadId>`), this duplicated context the session already had and kept re-sending old, stale messages on every follow-up.

## Changes

Channel history is now sent exactly once, restricted to the moment a thread conversation starts:

- **Fresh thread opened off a mention** — seeded with the surrounding parent-channel messages as a one-shot context block.
- **First mention in a thread the bot does not own** — seeded with the thread history so far (tracked per thread so later mentions don't re-fetch).
- **Follow-ups in bot threads, DMs, and non-thread fallbacks** — no history fetch at all; the agent session's own memory carries the conversation.

The bot's own messages are excluded from seeded history, since they came out of an agent session and would only duplicate what it already knows. History fetching was extracted into a `fetchHistoryContext` helper, and thread creation now happens before seeding so the context decision keys off the final conversation id.

## Tests

Added three tests pinning the new behavior (seed on new thread excluding bot messages, no re-send on bot-thread follow-ups, foreign threads seeded only once). Full suite: 332 tests pass, `tsc` and `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RCKatjUnKH1iXouoiWeaTY

---
_Generated by [Claude Code](https://claude.ai/code/session_01RCKatjUnKH1iXouoiWeaTY)_