### PR TITLE
Show one informative tool-call status line instead of a growing list

### DIFF
--- a/src/core/agent-loop.ts
+++ b/src/core/agent-loop.ts
@@ -5,6 +5,7 @@ import type { DailyLog } from '../memory/daily-log.js'
 import type { MemoryStore } from '../memory/store.js'
 import { applySummaryTemplate } from './prompt-template.js'
 import { MessageBus } from './bus.js'
+import { formatToolLine, type ToolCallStatus } from './tool-format.js'
 import type { ModelClient } from './model-client.js'
 import type {
   AgentTurnUpdate,
@@ -14,17 +15,6 @@ import type {
   Logger,
   SentMessage
 } from './types.js'
-
-/**
- * Converts a raw tool name into a human-readable label safe for Telegram Markdown.
- * MCP tools arrive as mcp__ServerName__tool_name — strip the prefix and
- * replace underscores so Telegram does not interpret __x__ as bold formatting.
- */
-function formatToolName(name: string): string {
-  const mcpMatch = /^mcp__[^_]+(?:_[^_]+)*__(.+)$/.exec(name)
-  const bare = mcpMatch?.[1] ?? name
-  return bare.replace(/_/g, ' ')
-}
 
 /**
  * Central message-processing loop.
@@ -122,7 +112,10 @@ export class AgentLoop {
 
     let statusMessage: SentMessage | null = null
     let streamMessage: SentMessage | null = null
-    const toolUpdates: Array<{ id: string; label: string }> = []
+    // Only the most recent tool call is shown — each new call replaces the
+    // previous one in the same chat message instead of appending to a list.
+    let currentTool: { id: string; name: string; detail: string; status: ToolCallStatus } | null =
+      null
 
     const publishProgress = async (update: AgentTurnUpdate): Promise<void> => {
       if (update.kind === 'text_streaming') {
@@ -176,28 +169,36 @@ export class AgentLoop {
         kind: update.kind,
         toolName: update.toolName,
         toolUseId: update.toolUseId,
+        toolDetail: update.toolDetail,
         message: update.message
       })
 
       if (!this.channelManager) return
 
       const toolId = update.toolUseId ?? update.toolName ?? 'tool'
-      const toolLabel = formatToolName(update.toolName ?? 'tool')
 
       if (update.kind === 'tool_call_started') {
-        toolUpdates.push({ id: toolId, label: `🔧 ${toolLabel}` })
-      } else if (update.kind === 'tool_call_finished') {
-        const entry = toolUpdates.find((t) => t.id === toolId)
-        if (entry) entry.label = `✅ ${toolLabel}`
-      } else if (update.kind === 'tool_call_failed') {
-        const entry = toolUpdates.find((t) => t.id === toolId)
-        if (entry) entry.label = `❌ ${toolLabel}`
+        currentTool = {
+          id: toolId,
+          name: update.toolName ?? 'tool',
+          detail: update.toolDetail ?? '',
+          status: 'running'
+        }
+      } else if (currentTool && currentTool.id === toolId) {
+        currentTool = {
+          ...currentTool,
+          ...(update.toolDetail ? { detail: update.toolDetail } : {}),
+          status: update.kind === 'tool_call_failed' ? 'failed' : 'done'
+        }
+      } else {
+        // A result for a tool that is no longer on screen — nothing to redraw.
+        return
       }
 
       // Don't overwrite a streaming text draft with tool status
       if (streamMessage) return
 
-      const statusText = toolUpdates.map((t) => t.label).join('\n')
+      const statusText = formatToolLine(currentTool.status, currentTool.name, currentTool.detail)
       try {
         if (statusMessage) {
           await this.channelManager.editMessage(statusMessage, statusText)

--- a/src/core/claude-client.ts
+++ b/src/core/claude-client.ts
@@ -6,6 +6,7 @@ import type { ModelClient } from './model-client.js'
 import { SessionStore } from './session-store.js'
 import { buildSystemPrompt } from './system-prompt.js'
 import { TranscriptLogger } from './transcript-logger.js'
+import { summarizeToolInput } from './tool-format.js'
 import type { AgentTurnUpdate, Logger, ToolContext } from './types.js'
 
 function summarizeToolResult(content: unknown): string {
@@ -59,7 +60,8 @@ export class ClaudeClient implements ModelClient {
     message: SDKMessage,
     conversationKey: string,
     context: ToolContext,
-    toolNamesByCallId: Map<string, string>
+    toolNamesByCallId: Map<string, string>,
+    toolDetailsByCallId: Map<string, string>
   ): Promise<{ text: string }> {
     let text = ''
 
@@ -82,17 +84,21 @@ export class ClaudeClient implements ModelClient {
           })
         } else if (block.type === 'tool_use') {
           if (block.id) toolNamesByCallId.set(block.id, block.name)
+          const detail = summarizeToolInput(block.name, block.input)
+          if (block.id && detail) toolDetailsByCallId.set(block.id, detail)
           this.logger.info('claude.tool_call_started', {
             conversationKey,
             toolName: block.name,
-            toolUseId: block.id
+            toolUseId: block.id,
+            toolDetail: detail
           })
           await this.publishUpdate(context, {
             kind: 'tool_call_started',
             conversationKey,
             message: `Using tool: ${block.name}`,
             toolName: block.name,
-            ...(block.id ? { toolUseId: block.id } : {})
+            ...(block.id ? { toolUseId: block.id } : {}),
+            ...(detail ? { toolDetail: detail } : {})
           })
         }
       }
@@ -115,6 +121,7 @@ export class ClaudeClient implements ModelClient {
           }
           const toolUseId = toolResult.tool_use_id
           const toolName = toolUseId ? toolNamesByCallId.get(toolUseId) : undefined
+          const toolDetail = toolUseId ? toolDetailsByCallId.get(toolUseId) : undefined
           const summary = summarizeToolResult(toolResult.content)
           const failed = summary.includes('error')
 
@@ -131,7 +138,8 @@ export class ClaudeClient implements ModelClient {
               ? `Tool failed${toolName ? `: ${toolName}` : ''}`
               : `Tool completed${toolName ? `: ${toolName}` : ''}`,
             ...(toolName ? { toolName } : {}),
-            ...(toolUseId ? { toolUseId } : {})
+            ...(toolUseId ? { toolUseId } : {}),
+            ...(toolDetail ? { toolDetail } : {})
           })
         }
       }
@@ -154,6 +162,7 @@ export class ClaudeClient implements ModelClient {
 
     let responseText = ''
     const toolNamesByCallId = new Map<string, string>()
+    const toolDetailsByCallId = new Map<string, string>()
 
     try {
       for await (const message of query({
@@ -176,7 +185,8 @@ export class ClaudeClient implements ModelClient {
           message,
           conversationKey,
           context,
-          toolNamesByCallId
+          toolNamesByCallId,
+          toolDetailsByCallId
         )
         if (text) responseText = text
 

--- a/src/core/pi-client.ts
+++ b/src/core/pi-client.ts
@@ -18,6 +18,7 @@ import { SessionStore } from './session-store.js'
 import { buildSystemPrompt } from './system-prompt.js'
 import { TranscriptLogger } from './transcript-logger.js'
 import { createGuardrailExtension } from './guardrail-extension.js'
+import { summarizeToolInput } from './tool-format.js'
 import type { AgentTurnUpdate, Logger, ToolContext } from './types.js'
 
 /**
@@ -235,6 +236,7 @@ export class PiClient implements ModelClient {
 
     let responseText = ''
     let lastErrorText = ''
+    const toolDetailsByCallId = new Map<string, string>()
 
     const handler = (event: AgentSessionEvent): void => {
       if (event.type === 'message_update') {
@@ -255,14 +257,22 @@ export class PiClient implements ModelClient {
       if (event.type === 'tool_execution_start') {
         const toolName = event.toolName
         const toolUseId = event.toolCallId
-        this.logger.info('pi.tool_call_started', { conversationKey, toolName, toolUseId })
+        const toolDetail = summarizeToolInput(toolName, event.args)
+        if (toolDetail) toolDetailsByCallId.set(toolUseId, toolDetail)
+        this.logger.info('pi.tool_call_started', {
+          conversationKey,
+          toolName,
+          toolUseId,
+          toolDetail
+        })
         this.schedule(conversationKey, async () => {
           await this.publishUpdate(context, {
             kind: 'tool_call_started',
             conversationKey,
             message: `Using tool: ${toolName}`,
             toolName,
-            toolUseId
+            toolUseId,
+            ...(toolDetail ? { toolDetail } : {})
           })
         })
         return
@@ -270,6 +280,7 @@ export class PiClient implements ModelClient {
       if (event.type === 'tool_execution_end') {
         const toolName = event.toolName
         const toolUseId = event.toolCallId
+        const toolDetail = toolDetailsByCallId.get(toolUseId)
         const failed = event.isError === true
         if (failed) {
           lastErrorText = extractErrorText(event.result) || lastErrorText
@@ -283,7 +294,8 @@ export class PiClient implements ModelClient {
             conversationKey,
             message: failed ? `Tool failed: ${toolName}` : `Tool completed: ${toolName}`,
             toolName,
-            toolUseId
+            toolUseId,
+            ...(toolDetail ? { toolDetail } : {})
           })
         })
         return

--- a/src/core/tool-format.ts
+++ b/src/core/tool-format.ts
@@ -1,0 +1,144 @@
+/**
+ * Helpers for rendering tool-call activity as short, informative chat lines.
+ *
+ * Chat channels only show a single status message per turn, so each line has to
+ * carry enough context ("Bash: npm test" rather than just "Bash") to be useful.
+ */
+
+/** Maximum length of the detail suffix appended after the tool name. */
+const MAX_DETAIL = 120
+
+/**
+ * Converts a raw tool name into a human-readable label safe for Telegram Markdown.
+ * MCP tools arrive as mcp__ServerName__tool_name — strip the prefix and
+ * replace underscores so Telegram does not interpret __x__ as bold formatting.
+ */
+export function formatToolName(name: string): string {
+  const mcpMatch = /^mcp__[^_]+(?:_[^_]+)*__(.+)$/.exec(name)
+  const bare = mcpMatch?.[1] ?? name
+  return bare.replace(/_/g, ' ')
+}
+
+/** Collapses whitespace and truncates to keep status lines single-line and short. */
+function condense(value: string, max = MAX_DETAIL): string {
+  const flat = value.replace(/\s+/g, ' ').trim()
+  if (flat.length <= max) return flat
+  return `${flat.slice(0, max - 1)}…`
+}
+
+/** Shortens a path to its last two segments so long absolute paths stay readable. */
+function shortPath(value: string): string {
+  const parts = value.split('/').filter(Boolean)
+  if (parts.length <= 2) return value
+  return parts.slice(-2).join('/')
+}
+
+function asString(value: unknown): string | undefined {
+  if (typeof value === 'string' && value.trim()) return value
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+  return undefined
+}
+
+/**
+ * Picks the most informative argument for a tool call and renders it as a short
+ * detail string — the shell command for Bash, the file for Read/Edit/Write, the
+ * pattern for Grep, the URL for WebFetch, and so on.
+ *
+ * Falls back to the first meaningful string argument for unknown tools (including
+ * MCP tools), and returns an empty string when nothing useful is available.
+ */
+export function summarizeToolInput(toolName: string, input: unknown): string {
+  if (input == null || typeof input !== 'object') return ''
+  const args = input as Record<string, unknown>
+  const bare = /^mcp__[^_]+(?:_[^_]+)*__(.+)$/.exec(toolName)?.[1] ?? toolName
+  const key = bare.toLowerCase()
+
+  const pick = (...names: string[]): string | undefined => {
+    for (const name of names) {
+      const value = asString(args[name])
+      if (value) return value
+    }
+    return undefined
+  }
+
+  if (key === 'bash' || key === 'shell' || key === 'run_command') {
+    const command = pick('command', 'cmd', 'script')
+    if (command) return condense(command)
+    return condense(pick('description') ?? '')
+  }
+
+  if (key === 'read' || key === 'write' || key === 'edit' || key === 'notebookedit') {
+    const file = pick('file_path', 'filePath', 'path', 'notebook_path')
+    if (file) return shortPath(file)
+  }
+
+  if (key === 'grep' || key === 'search') {
+    const pattern = pick('pattern', 'query')
+    const path = pick('path', 'glob')
+    if (pattern && path) return condense(`${pattern} in ${shortPath(path)}`)
+    if (pattern) return condense(pattern)
+  }
+
+  if (key === 'glob' || key === 'ls' || key === 'list') {
+    const pattern = pick('pattern', 'path')
+    if (pattern) return condense(pattern)
+  }
+
+  if (key === 'task' || key === 'agent') {
+    const description = pick('description', 'subagent_type', 'prompt')
+    if (description) return condense(description, 80)
+  }
+
+  if (key === 'webfetch' || key === 'fetch') {
+    const url = pick('url')
+    if (url) return condense(url)
+  }
+
+  if (key === 'websearch') {
+    const query = pick('query')
+    if (query) return condense(query)
+  }
+
+  if (key === 'todowrite') {
+    const todos = args.todos
+    if (Array.isArray(todos)) {
+      const active = todos.find(
+        (t) =>
+          typeof t === 'object' && t !== null && (t as { status?: string }).status !== 'completed'
+      ) as { content?: string; activeForm?: string } | undefined
+      const label = active?.activeForm ?? active?.content
+      if (label) return condense(label, 80)
+      return `${todos.length} task${todos.length === 1 ? '' : 's'}`
+    }
+  }
+
+  // Unknown / MCP tools: fall back to the first meaningful string argument.
+  const preferred = pick('description', 'query', 'prompt', 'name', 'path', 'url', 'command')
+  if (preferred) return condense(preferred, 80)
+
+  for (const value of Object.values(args)) {
+    const str = asString(value)
+    if (str) return condense(str, 80)
+  }
+
+  return ''
+}
+
+/** Status marker for a tool call's lifecycle stage. */
+export type ToolCallStatus = 'running' | 'done' | 'failed'
+
+const STATUS_ICON: Record<ToolCallStatus, string> = {
+  running: '🔧',
+  done: '✅',
+  failed: '❌'
+}
+
+/**
+ * Renders one tool call as a single status line: icon, tool name, and the
+ * detail extracted from the tool's arguments when there is one.
+ */
+export function formatToolLine(status: ToolCallStatus, toolName: string, detail?: string): string {
+  const label = formatToolName(toolName)
+  const trimmed = detail?.trim()
+  return trimmed ? `${STATUS_ICON[status]} ${label}: ${trimmed}` : `${STATUS_ICON[status]} ${label}`
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -121,6 +121,8 @@ export interface AgentTurnUpdate {
   message: string
   toolName?: string
   toolUseId?: string
+  /** Short human-readable summary of the tool's arguments (e.g. the shell command). */
+  toolDetail?: string
   /** Partial accumulated response text, present when kind is 'text_streaming'. */
   text?: string
 }

--- a/tests/agent-loop.test.ts
+++ b/tests/agent-loop.test.ts
@@ -227,6 +227,87 @@ describe('AgentLoop', () => {
     await Promise.race([run, new Promise((resolve) => setTimeout(resolve, 25))])
   })
 
+  it('replaces the previous tool call with the next one and shows argument detail', async () => {
+    const bus = new MessageBus()
+    const claude = {
+      runTurn: vi.fn(async (_conversationKey: string, _input: string, context: any) => {
+        await context.onUpdate({
+          kind: 'tool_call_started',
+          conversationKey: 'telegram:42',
+          message: 'Using tool: Bash',
+          toolName: 'Bash',
+          toolUseId: 'tool-1',
+          toolDetail: 'npm test'
+        })
+        await context.onUpdate({
+          kind: 'tool_call_finished',
+          conversationKey: 'telegram:42',
+          message: 'Tool completed: Bash',
+          toolName: 'Bash',
+          toolUseId: 'tool-1',
+          toolDetail: 'npm test'
+        })
+        await context.onUpdate({
+          kind: 'tool_call_started',
+          conversationKey: 'telegram:42',
+          message: 'Using tool: Read',
+          toolName: 'Read',
+          toolUseId: 'tool-2',
+          toolDetail: 'core/agent-loop.ts'
+        })
+        await context.onUpdate({
+          kind: 'tool_call_failed',
+          conversationKey: 'telegram:42',
+          message: 'Tool failed: Read',
+          toolName: 'Read',
+          toolUseId: 'tool-2',
+          toolDetail: 'core/agent-loop.ts'
+        })
+        return 'final answer'
+      }),
+      startNewSession: vi.fn(async () => undefined),
+      closeAll: vi.fn()
+    }
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+
+    const sentMessage = { channel: 'telegram' as const, chatId: '42', messageId: '99' }
+    const channelManager = {
+      sendDirect: vi.fn(async () => sentMessage),
+      editMessage: vi.fn(async () => undefined)
+    }
+
+    const loop = new AgentLoop(bus, makeConfig(), claude as never, logger)
+    loop.setChannelManager(channelManager as any)
+
+    const run = loop.start()
+    await bus.publishInbound({
+      channel: 'telegram',
+      senderId: 'u1',
+      chatId: '42',
+      content: 'hello',
+      timestamp: new Date().toISOString()
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    // Only one status message is ever sent; later calls replace its content
+    expect(channelManager.sendDirect).toHaveBeenCalledTimes(1)
+    expect(channelManager.sendDirect).toHaveBeenCalledWith(
+      expect.objectContaining({ content: '🔧 Bash: npm test' })
+    )
+
+    const edits = channelManager.editMessage.mock.calls.map((call: any[]) => call[1])
+    expect(edits).toEqual([
+      '✅ Bash: npm test',
+      '🔧 Read: core/agent-loop.ts',
+      '❌ Read: core/agent-loop.ts',
+      'final answer'
+    ])
+
+    loop.stop()
+    await Promise.race([run, new Promise((resolve) => setTimeout(resolve, 25))])
+  })
+
   it('sends streaming text updates as draft messages and finalises with editMessage', async () => {
     const bus = new MessageBus()
     const claude = {

--- a/tests/tool-format.test.ts
+++ b/tests/tool-format.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+
+import { formatToolLine, formatToolName, summarizeToolInput } from '../src/core/tool-format.js'
+
+describe('formatToolName', () => {
+  it('strips the mcp prefix and underscores', () => {
+    expect(formatToolName('mcp__github__create_pull_request')).toBe('create pull request')
+    expect(formatToolName('Bash')).toBe('Bash')
+  })
+})
+
+describe('summarizeToolInput', () => {
+  it('shows the shell command for Bash', () => {
+    expect(summarizeToolInput('Bash', { command: 'npm test', description: 'Run tests' })).toBe(
+      'npm test'
+    )
+  })
+
+  it('falls back to the description when Bash has no command', () => {
+    expect(summarizeToolInput('Bash', { description: 'Run tests' })).toBe('Run tests')
+  })
+
+  it('shortens file paths for file tools', () => {
+    expect(
+      summarizeToolInput('Read', { file_path: '/home/user/proj/src/core/agent-loop.ts' })
+    ).toBe('core/agent-loop.ts')
+    expect(summarizeToolInput('Edit', { file_path: 'src/index.ts' })).toBe('src/index.ts')
+  })
+
+  it('combines pattern and path for Grep', () => {
+    expect(summarizeToolInput('Grep', { pattern: 'todo', path: 'src/core' })).toBe(
+      'todo in src/core'
+    )
+  })
+
+  it('uses the query for web tools', () => {
+    expect(summarizeToolInput('WebSearch', { query: 'claude pipe' })).toBe('claude pipe')
+    expect(summarizeToolInput('WebFetch', { url: 'https://example.com' })).toBe(
+      'https://example.com'
+    )
+  })
+
+  it('uses the description for sub-agent tasks', () => {
+    expect(summarizeToolInput('Task', { description: 'Find flaky tests', prompt: 'long...' })).toBe(
+      'Find flaky tests'
+    )
+  })
+
+  it('falls back to the first meaningful argument for unknown tools', () => {
+    expect(summarizeToolInput('mcp__github__issue_read', { issue_number: 12 })).toBe('12')
+  })
+
+  it('collapses whitespace and truncates long details', () => {
+    const detail = summarizeToolInput('Bash', { command: `echo   a\nb${'x'.repeat(300)}` })
+    expect(detail.length).toBeLessThanOrEqual(120)
+    expect(detail).toContain('echo a b')
+    expect(detail.endsWith('…')).toBe(true)
+  })
+
+  it('returns an empty string when there is nothing to show', () => {
+    expect(summarizeToolInput('Bash', {})).toBe('')
+    expect(summarizeToolInput('Bash', undefined)).toBe('')
+  })
+})
+
+describe('formatToolLine', () => {
+  it('renders status, name, and detail', () => {
+    expect(formatToolLine('running', 'Bash', 'npm test')).toBe('🔧 Bash: npm test')
+    expect(formatToolLine('done', 'Bash', 'npm test')).toBe('✅ Bash: npm test')
+    expect(formatToolLine('failed', 'Bash', 'npm test')).toBe('❌ Bash: npm test')
+  })
+
+  it('omits the separator when there is no detail', () => {
+    expect(formatToolLine('done', 'WebSearch')).toBe('✅ WebSearch')
+    expect(formatToolLine('done', 'WebSearch', '  ')).toBe('✅ WebSearch')
+  })
+})


### PR DESCRIPTION
## Problem

Tool activity appended one line per call to a single status message, so a long turn produced a wall of identical `✅ Bash` entries in Discord and Telegram — dozens of lines that said nothing about what actually ran.

## Change

Each tool call now **replaces** the previous one in the same message, and each line carries the most useful argument next to the tool name:

```
🔧 Bash: npm test
✅ Bash: npm test
🔧 Read: core/agent-loop.ts
❌ Read: core/agent-loop.ts
```

Detail extraction per tool: shell command for Bash (falling back to its description), the file for Read/Edit/Write/NotebookEdit (last two path segments), `pattern in path` for Grep, the pattern for Glob/LS, the description for Task/Agent, the URL for WebFetch, the query for WebSearch, the active item for TodoWrite, and a best-effort first meaningful argument for MCP and unknown tools. Details are whitespace-collapsed and truncated so lines stay short.

- `src/core/tool-format.ts` — new module with `formatToolName`, `summarizeToolInput`, and `formatToolLine` (`formatToolName` moved here from `agent-loop.ts`).
- `AgentTurnUpdate` gains an optional `toolDetail`; both `ClaudeClient` and `PiClient` populate it on `tool_call_started` and remember it per tool-use id so the finished/failed line keeps the same detail.
- `AgentLoop` tracks only the current tool call and edits the status message in place; results for a call that is no longer displayed are ignored rather than redrawing.

Streaming text still takes over the status message as before, and the final response still replaces it.

## Testing

- `tests/tool-format.test.ts` — new, covers name formatting, per-tool detail extraction, fallbacks, truncation, and line rendering.
- `tests/agent-loop.test.ts` — new case asserting one status message is sent and subsequent calls replace its content in order.
- `npm run lint`, `npm run build`, `npm run test:run` (345 tests) all pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q4zB4KMtC9r7Wbc18kSJio)_