### PR TITLE
feat(onboarding): add Sonnet 5 / Opus 5 presets to the claude harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,10 +162,16 @@ Configuration is stored in `~/.pi-pipe/settings.json` and created by the onboard
 | `allowFrom`     | Array of allowed user IDs (empty = allow everyone)                                                                            |
 | `allowChannels` | Discord-only: channel ID allowlist (empty/missing = allow all channels); thread messages match their parent channel too       |
 | `harness`       | Agent harness: `pi` (Pi Coding Agent SDK, multi-provider; default) or `claude` (Claude Agent SDK, Anthropic only)             |
-| `model`         | Model name (e.g. `claude-sonnet-4-5`, `gpt-5`, `kimi-k2`, or `provider/model-id`; non-Anthropic ids require the `pi` harness) |
+| `model`         | Model name (e.g. `claude-opus-5`, `gpt-5`, `kimi-k2`, or `provider/model-id`; non-Anthropic ids require the `pi` harness)     |
 | `workspace`     | Root directory the agent can access                                                                                           |
 | `personality`   | Optional: give your assistant a `name` and `traits` description                                                               |
 | `env`           | Optional: environment variables to inject at startup                                                                          |
+
+> **Picking a harness for newer Claude models.** The `pi` harness resolves `model`
+> against the Pi SDK's bundled model registry and throws `Unknown model` on ids it
+> doesn't recognise, so it trails Anthropic releases. The `claude` harness hands the
+> id straight to the Claude Agent SDK without validating it, so the newest models
+> (e.g. `claude-opus-5`) work there as soon as they ship.
 
 ### Authentication
 

--- a/src/onboarding/wizard.ts
+++ b/src/onboarding/wizard.ts
@@ -117,6 +117,9 @@ async function chooseHarness(
 /*  Step 6 – Choose model                                              */
 /* ------------------------------------------------------------------ */
 
+// The pi harness resolves ids against the Pi SDK's bundled model registry and
+// throws on anything it doesn't know, so these presets deliberately stay on
+// releases the registry has caught up with.
 const PI_MODEL_PRESETS: Record<string, string> = {
   '1': 'claude-haiku-4-5',
   '2': 'claude-sonnet-4-5',
@@ -125,18 +128,22 @@ const PI_MODEL_PRESETS: Record<string, string> = {
 
 // The Claude harness passes the model straight into the Claude Agent SDK, which
 // only accepts Anthropic models — so its preset list omits non-Anthropic
-// options and the free-form prompt is scoped to Anthropic model ids.
+// options and the free-form prompt is scoped to Anthropic model ids. The SDK
+// takes the id verbatim rather than validating it, so newer releases than the
+// pi registry knows about are selectable here.
 const CLAUDE_MODEL_PRESETS: Record<string, string> = {
   '1': 'claude-haiku-4-5',
-  '2': 'claude-sonnet-4-5'
+  '2': 'claude-sonnet-5',
+  '3': 'claude-opus-5'
 }
 
+/** Menu entry for "Other (free-form)" — the last option in both model menus. */
+const OTHER_MODEL_CHOICE = '4'
+
 function getModelChoiceNumber(model: string, harness: 'pi' | 'claude'): string {
-  if (model === 'claude-haiku-4-5') return '1'
-  if (model === 'claude-sonnet-4-5') return '2'
-  if (harness === 'claude') return '3'
-  if (model === 'gpt-5') return '3'
-  return '4'
+  const presets = harness === 'claude' ? CLAUDE_MODEL_PRESETS : PI_MODEL_PRESETS
+  const preset = Object.entries(presets).find(([, id]) => id === model)
+  return preset ? preset[0] : OTHER_MODEL_CHOICE
 }
 
 async function chooseModel(
@@ -150,16 +157,17 @@ async function chooseModel(
     console.log(
       '\nWhich Claude model would you like to use? (the Claude harness is Anthropic-only)\n' +
         '  1) Claude Haiku 4.5  (needs ANTHROPIC_API_KEY)\n' +
-        '  2) Claude Sonnet 4.5 (needs ANTHROPIC_API_KEY)\n' +
-        '  3) Other (free-form Anthropic model id, e.g. claude-opus-4-1)\n'
+        '  2) Claude Sonnet 5   (needs ANTHROPIC_API_KEY)\n' +
+        '  3) Claude Opus 5     (needs ANTHROPIC_API_KEY)\n' +
+        '  4) Other (free-form Anthropic model id, e.g. claude-fable-5)\n'
     )
-    const choice = await ask(rl, `Enter 1–3 [${defaultChoice}]: `)
+    const choice = await ask(rl, `Enter 1–4 [${defaultChoice}]: `)
     const effectiveChoice = choice || defaultChoice
     if (effectiveChoice in CLAUDE_MODEL_PRESETS) return CLAUDE_MODEL_PRESETS[effectiveChoice]!
 
     const currentLabel = currentModel ? ` [${currentModel}]` : ''
-    const custom = await ask(rl, `Enter Anthropic model id (e.g. claude-opus-4-1)${currentLabel}: `)
-    return custom || currentModel || 'claude-sonnet-4-5'
+    const custom = await ask(rl, `Enter Anthropic model id (e.g. claude-fable-5)${currentLabel}: `)
+    return custom || currentModel || 'claude-sonnet-5'
   }
 
   console.log(


### PR DESCRIPTION
The `claude` harness hands the model id straight to the Claude Agent SDK without validating it, so the newest models are selectable there as soon as they ship. The `pi` harness resolves ids against the Pi SDK's bundled registry and throws `Unknown model` on anything it doesn't recognise, so it trails Anthropic releases.

This adds Sonnet 5 and Opus 5 as claude-harness presets and documents that tradeoff in the README so the harness choice is an informed one.

Verified both ids resolve against `GET /v1/models`:

```
claude-sonnet-5   -> Claude Sonnet 5
claude-opus-5     -> Claude Opus 5
```

Also replaces the hand-maintained if-chain in `getModelChoiceNumber` with a reverse lookup over the preset maps — the old version had `claude-sonnet-4-5` hardcoded to `'2'` for both harnesses and would have returned the wrong menu index the moment the claude preset list diverged. Adding a preset now requires editing one map instead of two places.

`tsc` clean, 345/345 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)